### PR TITLE
Enabled Typescript auto detection! Simplified utils.ts

### DIFF
--- a/.idea/typescript-compiler.xml
+++ b/.idea/typescript-compiler.xml
@@ -5,6 +5,6 @@
     <option name="generateSourceMap" value="false" />
     <option name="outDirectory" value="$ModuleFileDir$" />
     <option name="useConfig" value="true" />
-    <option name="versionType" value="EMBEDDED" />
+    <option name="showAllErrors" value="true" />
   </component>
 </project>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "application-name",
   "version": "0.0.1",
   "dependencies": {
-    "typescript": "^2.2.1",
     "warc": "^1.0.0",
     "unzip": "^0.1.11",
     "hx-tokenizer": "^1.0.0",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,16 +1,14 @@
 export class UnsupportedProtocolError extends Error {
-    constructor(message: string) {
-        super();
+    constructor(message? : string) {
+        super(message);
         this.name = 'UnsupportedProtocolError';
-        this.message = (message || '');
     }
 }
 
 
 export class AlreadyExistsError extends Error {
-    constructor(message : string) {
-        super();
+    constructor(message? : string) {
+        super(message);
         this.name = 'AlreadyExistsError';
-        this.message = (message || '');
     }
 }


### PR DESCRIPTION
Re-enabled Intellij's Typescript compiler auto detection mode. This ensures that we're always using the lastest Typescript version. The embedded Typescript version 2.0.8 has some bugs regarding custom Error classes.
Running `npm install` will always install the latest version of Typescript. Intellij has to be restarted to be able use the latest version though. If Typescript isn't installed via NPM, it will use the embedded version.
This is just a "quality of life" feature and the corresponding config file can be added to `.gitignore` if someone thinks it's really annoying.

Also simplified `utils.ts`.