### PR TITLE
Adding a new function for extracting English pages from common crawl

### DIFF
--- a/src/extractEnglishPages.ts
+++ b/src/extractEnglishPages.ts
@@ -1,0 +1,31 @@
+/**
+ * Created by Anshul on 3/6/2017.
+ */
+
+const path = require('path');
+const fs = require('fs');
+var franc = require('franc');
+const WARCStream = require('warc');
+var writeStream = fs.createWriteStream('./data/english.wet', { flags : 'w' });
+
+// extracting only english pages
+function extractEnglishPages(filepath : string) : void {
+
+    //choose wet files and other common crawl formats
+    if (path.extname(filepath).match(/\.wet|\.wat|\.warc/)){
+
+        // open each file in the folder as stream and pipe it to the warc parser
+        const WARCParser = new WARCStream();
+        fs.createReadStream(filepath).pipe(WARCParser).on('data', data => {
+
+            // write only english content to a new file
+            const content: string = data.content.toString('utf8');
+            var testString = content.substring(0,500);
+            if(franc(testString).match("eng")){
+                writeStream.write(content);
+            }
+        });
+    }
+}
+
+extractEnglishPages("./data/CC-MAIN-20170116095119-00016-ip-10-171-10-70.ec2.internal.warc.wet");


### PR DESCRIPTION
I checked if franc was suitable for extracting English pages. I tested with different amounts of initial web pages data, and these were the results for a .wet file of around 400 mb size.

1. Using all of the web page ---> Text file size ~200 mb for English pages
2. Using first 100 characters ---> Text file size ~100 mb for English pages
3. Using first 300 character ---> Text file size ~160 mb for English pages
4. Using first 500 character ---> Text file size ~180 mb for English pages

Run 4 took around 5 mins on my PC. Didn't add call to app.ts as a lot more refinements are yet to be made.