### PR TITLE
Tested time to run natural vs node-snowball

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "cld": "^2.4.7",
     "natural": "^0.5.0",
     "unzip": "^0.1.11",
-    "warc": "^1.0.0"
+    "warc": "^1.0.0",
+    "node-snowball": "^0.2.0"
   },
   "devDependencies": {
     "@types/node": "^7.0.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,4 +8,4 @@ import {TestRuns} from "./test-runs";
 // there runs assume that the file is already downloaded -> no waiting
 //TestRuns.testTLD();
 //TestRuns.testLanguageExtractor_super_slow();
-TestRuns.testLanguageExtractor_slightly_better();
+TestRuns.testPreProcessingChain();

--- a/src/word-preprocessor.ts
+++ b/src/word-preprocessor.ts
@@ -1,5 +1,6 @@
 export class WordPreprocessor {
 
+    static snowball = require('node-snowball');
     static natural = require('natural');
     static tokenizer = new WordPreprocessor.natural.WordTokenizer();
     static stemHashes = {};
@@ -44,7 +45,10 @@ export class WordPreprocessor {
 
             //Check if a stem for the token has already been hashed, if not create stem and hash it.
             if(!(token in WordPreprocessor.stemHashes)) {
+                /*
                 WordPreprocessor.stemHashes[token] = WordPreprocessor.natural.PorterStemmer.stem(token);
+                */
+                WordPreprocessor.stemHashes[token] = WordPreprocessor.snowball.stemword(token, 'english');
             }
 
             /*


### PR DESCRIPTION
Took me me on average 48s to stem all english webpages with `natural` and 39s with `node-snowball`. That's roughly a 19% improvement. That's detecting language and stemming. If we subtract the 6s it takes me to detect the language, we're talking about an improvement of roughly 21%.