### PR TITLE
Direct processing without caching on disk

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,10 +3,10 @@ import {TestRuns} from "./test-runs";
 // don't run multiple test runs simultaneously!
 
 // run this to download file
-//TestRuns.testDownloadUnpackingAndStemming();
+TestRuns.testDownloadUnpackingAndStemming();
 
 // there runs assume that the file is already downloaded -> no waiting
 //TestRuns.testTLD();
 //TestRuns.testLanguageExtractor_super_slow();
 //TestRuns.testPreProcessingChain();
-TestRuns.testTermSearch();
+//TestRuns.testTermSearch();

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import {TestRuns} from "./test-runs";
 
 // run this to download file
 TestRuns.testDownloadUnpackingAndStemming();
+//TestRuns.testStreams();
 
 // there runs assume that the file is already downloaded -> no waiting
 //TestRuns.testTLD();

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,12 +2,17 @@ import {TestRuns} from "./test-runs";
 
 // don't run multiple test runs simultaneously!
 
-// run this to download file
-TestRuns.testDownloadUnpackingAndStemming();
-//TestRuns.testStreams();
+// run one of these to download and save file
+//TestRuns.testDownloadUnpackingAndStemming();
+//TestRuns.testStreamedDownloadAndUnpacking();
+
+// run this to download and process directly (no saving)
+TestRuns.testStreamedDownloadUnpackingAndProcessing();
 
 // there runs assume that the file is already downloaded -> no waiting
 //TestRuns.testTLD();
 //TestRuns.testLanguageExtractor_super_slow();
 //TestRuns.testPreProcessingChain();
+
+// other tests
 //TestRuns.testTermSearch();

--- a/src/language-extractor.ts
+++ b/src/language-extractor.ts
@@ -60,8 +60,8 @@ export class LanguageExtractor {
             let page : WebPage = new WebPage(data);
             // write only if the web page object is in english AND really represents a web page (and not the first entry of a WET file)
 
-            let tld = page.getTLD();
-            this.isWebPageInLanguage(page, searchLanguage, tld, function(result : boolean) {
+            //let tld = page.getTLD();
+            this.isWebPageInLanguage(page, searchLanguage, function(result : boolean) {
                 if(result) {
                     console.log('writing entry #' + entryID + '!');
 
@@ -101,9 +101,10 @@ export class LanguageExtractor {
      *
      * @param page                  web page object (constructed from WARC parser data)
      * @param searchLanguage        language string
+     * @param callback
      * @returns {boolean}
      */
-    public static isWebPageInLanguage(page : WebPage, searchLanguage : string, tld : string,
+    public static isWebPageInLanguage(page : WebPage, searchLanguage : string,
                                       callback: (result : boolean) => void) {
         const content: string = page.content;
 
@@ -112,9 +113,9 @@ export class LanguageExtractor {
         const testStringEnd: number = (content.length / 2) + 250 < content.length ? (content.length / 2) + 250 : content.length;
         const testString = content.substring(testStringStart, testStringEnd);
 
-        LanguageExtractor.cld.detect(testString, { tldHint: tld}, function(err, result) {
+        LanguageExtractor.cld.detect(testString, { tldHint: page.getTLD()}, function(err, result) {
             if(err) {
-                console.log(err);
+                console.log(err + "page tld: " + page.getTLD());
                 callback(false);
             } else {
                 callback(result.reliable && result.languages[0].code == searchLanguage);

--- a/src/test-runs.ts
+++ b/src/test-runs.ts
@@ -42,7 +42,7 @@ export class TestRuns {
 
         console.log("starting download ...");
 
-        Downloader.downloadFile(TestRuns.crawlBaseUrl + TestRuns.fileName_packed, TestRuns.dataFolder, (err, filepath) => {
+        Downloader.downloadToFile(TestRuns.crawlBaseUrl + TestRuns.fileName_packed, TestRuns.dataFolder, (err, filepath) => {
 
             // downloader is ready
             if (err) {

--- a/src/test-runs.ts
+++ b/src/test-runs.ts
@@ -347,6 +347,10 @@ export class TestRuns {
     }
 
 
+    /**
+     * Download and process file completely without caching on disk.
+     * The processing starts as soon as we get the first bytes from the server.
+     */
     public static testStreamedDownloadUnpackingAndProcessing() {
         console.log("Sending request... ");
 
@@ -366,15 +370,12 @@ export class TestRuns {
             decompressed.pipe(WARCParser).on('data', data => {
 
                 // getting WET entries here
-
                 let p = new WebPage(data);
                 let tld = p.getTLD();
 
-
-                // run LanguageExtractor, WordPreprocessor here
-                // run LanguageExtractor, WordPreprocessor here
-                // run LanguageExtractor, WordPreprocessor here
-
+                // run filtering here
+                // run LanguageExtractor here
+                // run WordPreprocessor here
 
                 // print only a few entries
                 if (entryID % 100 == 0) {

--- a/src/test-runs.ts
+++ b/src/test-runs.ts
@@ -15,6 +15,7 @@ export class TestRuns {
     static fs = require('fs');
     static path = require('path');
     static WARCStream = require('warc');
+    //static rwStream = require("read-write-stream");
 
     static crawlBaseUrl = 'https://commoncrawl.s3.amazonaws.com/crawl-data/CC-MAIN-2017-04/segments/1484560279169.4/wet/';
     static dataFolder = './data/';
@@ -208,7 +209,7 @@ export class TestRuns {
 
             let tld = p.getTLD();
 
-            LanguageExtractor.isWebPageInLanguage(p, 'en', tld, function(result : boolean) {
+            LanguageExtractor.isWebPageInLanguage(p, 'en', function(result : boolean) {
                 console.log("Entry #" + entryID
                     + "\tTLD: "+ tld + " "
                     + "\tIsEnglish: " + result + " "
@@ -250,10 +251,9 @@ export class TestRuns {
 
             let p = new WebPage(data);
 
-            let tld = p.getTLD();
-
-            LanguageExtractor.isWebPageInLanguage(p, 'en', tld, function(result : boolean) {
+            LanguageExtractor.isWebPageInLanguage(p, 'en', function(result : boolean) {
                 if (result) {
+                    console.log("processing result ");
                     WordPreprocessor.process(p.content);
                 }
             });
@@ -325,5 +325,71 @@ export class TestRuns {
     }
 
     //endregion
+
+
+    /**
+     * Downloads and unpacks the WET file without temporary caching on disk.
+     * Only the unpacked result is written on disk. No processing.
+     */
+    public static testStreamedDownloadAndUnpacking() {
+        Downloader.getResponse(TestRuns.crawlBaseUrl + TestRuns.fileName_packed, (err, response) => {
+            if (err) {
+                console.log(err);
+                return;
+            }
+
+            // unpack & write to file
+            let decompressed = Unpacker.decompressGZipStream(response);
+            let output = Unpacker.fs.createWriteStream(TestRuns.path.join(TestRuns.dataFolder, TestRuns.fileName_unpacked));
+            decompressed.pipe(output);
+
+        });
+    }
+
+
+    public static testStreamedDownloadUnpackingAndProcessing() {
+        console.log("Sending request... ");
+
+        Downloader.getResponse(TestRuns.crawlBaseUrl + TestRuns.fileName_packed, (err, response) => {
+            if (err) {
+                console.log(err);
+                return;
+            }
+            console.log("start receiving and decompressing data... (starting timer)");
+
+            let timeStart = new Date().getTime();
+            let entryID = 0;
+
+            // unpack & feed into WARC parser
+            let decompressed = Unpacker.decompressGZipStream(response);
+            const WARCParser = new TestRuns.WARCStream();
+            decompressed.pipe(WARCParser).on('data', data => {
+
+                // getting WET entries here
+
+                let p = new WebPage(data);
+                let tld = p.getTLD();
+
+
+                // run LanguageExtractor, WordPreprocessor here
+                // run LanguageExtractor, WordPreprocessor here
+                // run LanguageExtractor, WordPreprocessor here
+
+
+                // print only a few entries
+                if (entryID % 100 == 0) {
+                    let duration = new Date().getTime() -  timeStart;
+                    console.log("entry #" + entryID
+                        + "\tTLD: " + tld
+                        + " \t\ttime passed: " + duration + " ms"
+                        + "\t\tavg time per entry: " + Math.round(duration / (entryID+1) * 1000) / 1000 + "ms");
+                }
+                entryID++;
+
+
+            });
+
+        });
+    }
 
 }

--- a/src/unpacker.ts
+++ b/src/unpacker.ts
@@ -1,6 +1,5 @@
 import {AlreadyExistsError} from './utils';
-import {ReadStream} from "fs";
-import {WriteStream} from "fs";
+import ReadableStream = NodeJS.ReadableStream;
 
 export class Unpacker {
 
@@ -48,32 +47,26 @@ export class Unpacker {
             let input = Unpacker.fs.createReadStream(gzipFilePath);
             let output = Unpacker.fs.createWriteStream(outputFilePath);
 
+            let decompressed = Unpacker.decompressGZipStream(input);
+            decompressed.pipe(output);
+
             // call callback if defined
             output.on("close", function () {
                 if (callback) { callback(undefined, outputFilePath); }
             });
 
-            Unpacker.unpackGZipStreamToStream(input, output);
         }
     }
 
-
     /**
+     *
      * Unpack a gzipped stream into another stream.
-     * @param input     gzipped stream
-     * @param output    output stream
-     * @param callback  optional callback, called when output is closed
+     * @param input                 gzipped stream
+     * @returns {ReadableStream}    decompressed stream
      */
-    public static unpackGZipStreamToStream(input : ReadStream,
-                                           output : WriteStream,
-                                           callback? : () => void ) : void {
-
+    public static decompressGZipStream(input : ReadableStream) : ReadableStream {
         const gunzip = Unpacker.zlib.createGunzip();
-        input.pipe(gunzip).pipe(output);
-
-        // call callback if defined
-        if (callback)   output.on("close", callback);
-
+        return input.pipe(gunzip);
     }
 
 

--- a/src/unpacker.ts
+++ b/src/unpacker.ts
@@ -58,7 +58,12 @@ export class Unpacker {
     }
 
 
-
+    /**
+     * Unpack a gzipped stream into another stream.
+     * @param input     gzipped stream
+     * @param output    output stream
+     * @param callback  optional callback, called when output is closed
+     */
     public static unpackGZipStreamToStream(input : ReadStream,
                                            output : WriteStream,
                                            callback? : () => void ) : void {


### PR DESCRIPTION
Resolving issue #33 : Download and process file completely without caching on disk. The processing starts as soon as we get the first bytes from the server.
example usage implemented in `test-runs.ts` > `testStreamedDownloadUnpackingAndProcessing()`