### PR TITLE
Nb #67 cc index

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,7 @@ import {TestRuns} from "./test-runs";
 // Run one of these to create a new file with filtered data:
 // TestRuns.testExtractAllEnglishPages();   // WET file must already be downloaded!
 // TestRuns.createFilteredSampleDataForGroups3_4();
- TestRuns.getMozartFromWiki();
+ TestRuns.getWebsiteByURL();
 
 
 // These runs require the WET file to be already downloaded and unpacked:

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,7 @@ import {TestRuns} from "./test-runs";
 // Run one of these to create a new file with filtered data:
 // TestRuns.testExtractAllEnglishPages();   // WET file must already be downloaded!
 // TestRuns.createFilteredSampleDataForGroups3_4();
-// TestRuns.getMozartFromWiki();
+ TestRuns.getMozartFromWiki();
 
 
 // These runs require the WET file to be already downloaded and unpacked:
@@ -22,7 +22,7 @@ import {TestRuns} from "./test-runs";
 //TestRuns.testWetManager();
 
 // test cc index
-TestRuns.testCCIndex();
+//TestRuns.testCCIndex();
 
 
 // Most advanced test run so far:

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,7 @@ import {TestRuns} from "./test-runs";
 // Run one of these to create a new file with filtered data:
 // TestRuns.testExtractAllEnglishPages();   // WET file must already be downloaded!
 // TestRuns.createFilteredSampleDataForGroups3_4();
-TestRuns.getMozartFromWiki();
+// TestRuns.getMozartFromWiki();
 
 
 // These runs require the WET file to be already downloaded and unpacked:
@@ -20,6 +20,9 @@ TestRuns.getMozartFromWiki();
 
 //Testing of WetManager
 //TestRuns.testWetManager();
+
+// test cc index
+TestRuns.testCCIndex();
 
 
 // Most advanced test run so far:

--- a/src/cc-index.ts
+++ b/src/cc-index.ts
@@ -31,6 +31,8 @@ export class CCIndex {
      * Takes a URL to look up, queries the CC index, parses the CC response and returns
      * an array of relative paths to all WET files tha should include the URL.
      *
+     * Either an error or at least one path are passed to the callback. If no WET files were found, an error is passed.
+     *
      * @param lookupURL             URL to look up in the CC index
      * @param callback              will be called with an array of paths to WET files (set of strings)
      * @param ccIndexPageURL        (optional) base URL of the CC index page; if not provided -> defaultCCIndex is used
@@ -46,7 +48,12 @@ export class CCIndex {
             // and create WET paths
             let wetPaths = CCIndex.constructWETPaths(lookupURL, resObjs);
 
-            callback(undefined, wetPaths);
+            if (wetPaths.length < 1) {
+                callback(new Error("No WET files found for " + lookupURL));
+            } else {
+                callback(undefined, wetPaths);
+            }
+
 
         }, ccIndexPageURL);
 

--- a/src/cc-index.ts
+++ b/src/cc-index.ts
@@ -68,7 +68,7 @@ export class CCIndex {
      * @param callback              (optional) will be called with the response body string; if not provided -> output to console
      * @param ccIndexPageURL        (optional) base URL of the CC index page; if not provided -> defaultCCIndex is used
      */
-    public static lookUpURL(lookupURL : string,
+    private static lookUpURL(lookupURL : string,
                             callback? : (err? : Error, body? : string) => void,
                             ccIndexPageURL? : string) {
 
@@ -102,7 +102,7 @@ export class CCIndex {
      * @param resp      CC index response string
      * @returns {Array} array of response objects
      */
-    public static parseStringToCCIndexResponse(resp : string) : Array<CCIndexResponse> {
+    private static parseStringToCCIndexResponse(resp : string) : Array<CCIndexResponse> {
         let result : Array<CCIndexResponse> = [];
 
         let lines = resp.split(/\n/);
@@ -158,7 +158,7 @@ export class CCIndex {
      * @param resObjs               parsed response objects from the CC index
      * @returns {Array<string>}     (relative) paths to WET files that contain websites with given url
      */
-    public static constructWETPaths(lookupURL : string, resObjs : Array<CCIndexResponse>) : Array<string> {
+    private static constructWETPaths(lookupURL : string, resObjs : Array<CCIndexResponse>) : Array<string> {
         lookupURL = lookupURL.replace("https://", "").replace("http://", ""); // remove http(s)
 
         let paths = new Set();

--- a/src/cc-index.ts
+++ b/src/cc-index.ts
@@ -40,5 +40,26 @@ export class CCIndex {
     }
 
 
+    public static parseCCIndexResponse(resp : string) : Array<Object> {
+        // convert each line to a JSON object and return and array of those objects
+        let result = [];
+
+        let lines = resp.split(/\n/);
+        for (let line of lines) {
+            if (line.length < 2) continue; // ignore empty/short lines
+            let json;
+            try {
+                json = JSON.parse(line);
+            } catch (e) {
+                continue; // ignore invalid JSONS
+            }
+            // line is ok
+            result.push(json);
+        }
+
+        return result;
+
+    }
+
 
 }

--- a/src/cc-index.ts
+++ b/src/cc-index.ts
@@ -1,13 +1,34 @@
 import {Downloader} from "./downloader";
 
+/**
+ * Objects of this class represent responses from the CommonCrawl index.
+ */
+export class CCIndexResponse {
 
+    public urlkey : string;
+    public timestamp : string;
+    public status : number;
+    public url : string;
+    public filename : string;
+    public length : number;
+    public mime : string;
+    public offset : number;
+    public digest : string;
+
+
+}
+
+/**
+ * This class allows interaction with the CommonCrawl index to search for specific URLs.
+ */
 export class CCIndex {
 
     public static defaultCCIndex = "http://index.commoncrawl.org/CC-MAIN-2017-04-index";
 
 
     /**
-     * Queries the CC index with a URL and calls the callback with the RAW response string.
+     * [HELPER FUNCTION]
+     * Query the CC index with a URL and call the callback with the RAW response string.
      *
      * @param lookupURL             URL to look up in the CC index
      * @param callback              (optional) will be called with the response body string; if not provided -> output to console
@@ -17,6 +38,7 @@ export class CCIndex {
                             callback? : (err? : Error, body? : string) => void,
                             ccIndexPageURL? : string) {
 
+        lookupURL = lookupURL.replace("https://", "").replace("http://", ""); // remove http(s)
         let indexPage = ccIndexPageURL || CCIndex.defaultCCIndex;
 
         let query = indexPage + "?url=" + encodeURI(lookupURL) + "&output=json";
@@ -39,10 +61,15 @@ export class CCIndex {
         });
     }
 
-
-    public static parseCCIndexResponse(resp : string) : Array<Object> {
-        // convert each line to a JSON object and return and array of those objects
-        let result = [];
+    /**
+     * [HELPER FUNCTION]
+     * Convert each line of the response to a CCIndexResponse object and return and array of those objects.
+     *
+     * @param resp      CC index response string
+     * @returns {Array} array of response objects
+     */
+    public static parseStringToCCIndexResponse(resp : string) : Array<CCIndexResponse> {
+        let result : Array<CCIndexResponse> = [];
 
         let lines = resp.split(/\n/);
         for (let line of lines) {
@@ -51,13 +78,71 @@ export class CCIndex {
             try {
                 json = JSON.parse(line);
             } catch (e) {
-                continue; // ignore invalid JSONS
+                continue; // ignore invalid JSONs
             }
-            // line is ok
-            result.push(json);
+
+            // line is ok, test for properties (strict! may not be supported for older crawls!)
+            if (!json.hasOwnProperty("urlkey")) continue;
+            if (!json.hasOwnProperty("timestamp")) continue;
+            if (!json.hasOwnProperty("status")) continue;
+            if (!json.hasOwnProperty("url")) continue;
+            if (!json.hasOwnProperty("filename")) continue;
+            if (!json.hasOwnProperty("length")) continue;
+            if (!json.hasOwnProperty("mime")) continue;
+            if (!json.hasOwnProperty("offset")) continue;
+            if (!json.hasOwnProperty("digest")) continue;
+
+            // create cc index response object
+            let resObj = new CCIndexResponse();
+            resObj.urlkey = json.urlkey;
+            resObj.timestamp = json.timestamp;
+            resObj.status = parseInt(json.status);
+            resObj.url = json.url;
+            resObj.filename = json.filename;
+            resObj.length = parseInt(json.length);
+            resObj.mime = json.mime;
+            resObj.offset = parseInt(json.offset);
+            resObj.digest = json.digest;
+
+            result.push(resObj);
         }
 
         return result;
+
+    }
+
+    /**
+     * [HELPER FUNCTION]
+     *
+     * Check whether the lookup URL is included in the CC index response.
+     * For each match, the WARC path is converted to a WET path.
+     * All valid paths are returned as a string array.
+     * Each path should start with "crawl-data/...".
+     *
+     * @param lookupURL             URL to look up
+     * @param resObjs               parsed response objects from the CC index
+     * @returns {Array<string>}     (relative) paths to WET files that contain websites with given url
+     */
+    public static constructWETPaths(lookupURL : string, resObjs : Array<CCIndexResponse>) : Array<string> {
+        lookupURL = lookupURL.replace("https://", "").replace("http://", ""); // remove http(s)
+
+        let paths = new Set();
+
+        for (let resObj of resObjs ) {
+            if (resObj.status != 200) continue; // we only want 200 responses
+
+            if (!resObj.url.toLowerCase().includes(lookupURL.toLowerCase())) {
+                console.warn("CC index response (" + resObj.url +  ") doesn't contain the lookup URL (" + lookupURL + ")!");
+                //continue;
+            }
+
+            // response seems to be valid, convert WARC path to WET path
+            let wetPath = resObj.filename.replace("/warc/", "/wet/").replace("warc.gz", "warc.wet.gz");
+            paths.add(wetPath);
+        }
+
+        return Array.from(paths);
+
 
     }
 

--- a/src/cc-index.ts
+++ b/src/cc-index.ts
@@ -29,14 +29,14 @@ export class CCIndex {
     /**
      * Main function to interact with the CommonCrawl index.
      * Takes a URL to look up, queries the CC index, parses the CC response and returns
-     * a set of relative paths to all WET files tha should include the URL.
+     * an array of relative paths to all WET files tha should include the URL.
      *
      * @param lookupURL             URL to look up in the CC index
-     * @param callback              will be called with the set of paths to WET files (set of strings)
+     * @param callback              will be called with an array of paths to WET files (set of strings)
      * @param ccIndexPageURL        (optional) base URL of the CC index page; if not provided -> defaultCCIndex is used
      */
     public static getWETPathsForURL(lookupURL : string,
-                                    callback : (err? : Error, wetPaths? : Set<string>) => void,
+                                    callback : (err? : Error, wetPaths? : Array<string>) => void,
                                     ccIndexPageURL? : string ) {
         CCIndex.lookUpURL(lookupURL, (err, rawResponse) => {
             if (err) {  callback(err);       return; }
@@ -142,16 +142,16 @@ export class CCIndex {
      * [HELPER FUNCTION]
      *
      * For each 200-response, the WARC path is converted to a WET path.
-     * All paths are returned as a string set (no duplicates). Each returned path should start with "crawl-data/...".
+     * All paths are returned as a string array (no duplicates). Each returned path should start with "crawl-data/...".
      *
      * This function also checks if the lookup URL is included in the CC index response.
      * If this is not the case, a warning will be shown.
      *
      * @param lookupURL             URL to look up
      * @param resObjs               parsed response objects from the CC index
-     * @returns {Set<string>}     (relative) paths to WET files that contain websites with given url
+     * @returns {Array<string>}     (relative) paths to WET files that contain websites with given url
      */
-    public static constructWETPaths(lookupURL : string, resObjs : Array<CCIndexResponse>) : Set<string> {
+    public static constructWETPaths(lookupURL : string, resObjs : Array<CCIndexResponse>) : Array<string> {
         lookupURL = lookupURL.replace("https://", "").replace("http://", ""); // remove http(s)
 
         let paths = new Set();
@@ -169,7 +169,7 @@ export class CCIndex {
             paths.add(wetPath);
         }
 
-        return paths;
+        return Array.from(paths);
 
 
     }

--- a/src/cc-index.ts
+++ b/src/cc-index.ts
@@ -27,6 +27,33 @@ export class CCIndex {
 
 
     /**
+     * Main function to interact with the CommonCrawl index.
+     * Takes a URL to look up, queries the CC index, parses the CC response and returns
+     * a set of relative paths to all WET files tha should include the URL.
+     *
+     * @param lookupURL             URL to look up in the CC index
+     * @param callback              will be called with the set of paths to WET files (set of strings)
+     * @param ccIndexPageURL        (optional) base URL of the CC index page; if not provided -> defaultCCIndex is used
+     */
+    public static getWETPathsForURL(lookupURL : string,
+                                    callback : (err? : Error, wetPaths? : Set<string>) => void,
+                                    ccIndexPageURL? : string ) {
+        CCIndex.lookUpURL(lookupURL, (err, rawResponse) => {
+            if (err) {  callback(err);       return; }
+
+            // got a raw response -> parse it
+            let resObjs = CCIndex.parseStringToCCIndexResponse(rawResponse);
+            // and create WET paths
+            let wetPaths = CCIndex.constructWETPaths(lookupURL, resObjs);
+
+            callback(undefined, wetPaths);
+
+        }, ccIndexPageURL);
+
+    }
+
+
+    /**
      * [HELPER FUNCTION]
      * Query the CC index with a URL and call the callback with the RAW response string.
      *
@@ -114,16 +141,17 @@ export class CCIndex {
     /**
      * [HELPER FUNCTION]
      *
-     * Check whether the lookup URL is included in the CC index response.
-     * For each match, the WARC path is converted to a WET path.
-     * All valid paths are returned as a string array.
-     * Each path should start with "crawl-data/...".
+     * For each 200-response, the WARC path is converted to a WET path.
+     * All paths are returned as a string set (no duplicates). Each returned path should start with "crawl-data/...".
+     *
+     * This function also checks if the lookup URL is included in the CC index response.
+     * If this is not the case, a warning will be shown.
      *
      * @param lookupURL             URL to look up
      * @param resObjs               parsed response objects from the CC index
-     * @returns {Array<string>}     (relative) paths to WET files that contain websites with given url
+     * @returns {Set<string>}     (relative) paths to WET files that contain websites with given url
      */
-    public static constructWETPaths(lookupURL : string, resObjs : Array<CCIndexResponse>) : Array<string> {
+    public static constructWETPaths(lookupURL : string, resObjs : Array<CCIndexResponse>) : Set<string> {
         lookupURL = lookupURL.replace("https://", "").replace("http://", ""); // remove http(s)
 
         let paths = new Set();
@@ -141,7 +169,7 @@ export class CCIndex {
             paths.add(wetPath);
         }
 
-        return Array.from(paths);
+        return paths;
 
 
     }

--- a/src/cc-index.ts
+++ b/src/cc-index.ts
@@ -1,0 +1,44 @@
+import {Downloader} from "./downloader";
+
+
+export class CCIndex {
+
+    public static defaultCCIndex = "http://index.commoncrawl.org/CC-MAIN-2017-04-index";
+
+
+    /**
+     * Queries the CC index with a URL and calls the callback with the RAW response string.
+     *
+     * @param lookupURL             URL to look up in the CC index
+     * @param callback              (optional) will be called with the response body string; if not provided -> output to console
+     * @param ccIndexPageURL        (optional) base URL of the CC index page; if not provided -> defaultCCIndex is used
+     */
+    public static lookUpURL(lookupURL : string,
+                            callback? : (err? : Error, body? : string) => void,
+                            ccIndexPageURL? : string) {
+
+        let indexPage = ccIndexPageURL || CCIndex.defaultCCIndex;
+
+        let query = indexPage + "?url=" + encodeURI(lookupURL) + "&output=json";
+
+        Downloader.getResponse(query, (err, res) => {
+            if (err) {
+                if (callback) callback(err); else console.error(err);
+                return;
+            }
+
+            // get full response
+            let body = '';
+            res.on('data', (chunk) => {
+               body += chunk;
+            });
+            res.on('end', () => {
+                if (callback) callback(undefined, body); else console.log("response body for " + lookupURL + ":\n" + body);
+            });
+
+        });
+    }
+
+
+
+}

--- a/src/test-runs.ts
+++ b/src/test-runs.ts
@@ -185,24 +185,22 @@ export class TestRuns {
 
                     });
                 });
-
-
-
-
             });
     }
 
 
-    // writes the wiki mozart page to a file
-    public static getMozartFromWiki() {
-        let searchURI = "en.wikipedia.org/wiki/Wolfgang_Amadeus_Mozart";
+    /**
+     * Query the CC index with an URL, find a WET file that contains the page and extract it.
+     */
+    public static getWebsiteByURL() {
+        let outputFileName = "hereIsWhatIFound.wet";
+        let searchURI = "https://en.wikipedia.org/wiki/HTTP_301";
         let ccBasePath = "https://commoncrawl.s3.amazonaws.com/";
 
         console.log("looking up " + searchURI);
 
-        CCIndex.getWETPathsForURL(searchURI, (err, wetPaths) => {
-            if (err) { console.log(err); return; }
-            if (wetPaths.length < 1) { console.log("no WET file found!"); return;}
+        CCIndex.getWETPathsForURL(searchURI, function (err, wetPaths) {
+            if (err) { console.log(err);  return; }
 
             let relativePathToFirstWET = wetPaths[0];
             console.log("found " + wetPaths.length + " results");
@@ -213,8 +211,8 @@ export class TestRuns {
                 if(err) { console.log(err); return; }
 
                 let entryID = 0;
-                let outputFile = TestRuns.dataFolder + "mozartFromWiki.wet";
-                const writeStream = LanguageExtractor.fs.createWriteStream(outputFile, {flags: 'w'});
+                let outputFilePath = TestRuns.path.join(TestRuns.dataFolder, outputFileName);
+                const writeStream = LanguageExtractor.fs.createWriteStream(outputFilePath, {flags: 'w'});
 
                 let warcParser = new TestRuns.WARCStream();
                 result.pipe(warcParser).on('data', data => {

--- a/src/test-runs.ts
+++ b/src/test-runs.ts
@@ -478,7 +478,11 @@ export class TestRuns {
                 return;
             }
 
-            console.log("CC Index response body:\n" + body);
+            console.log("CC Index response body, parsed:\n");
+            let objects = CCIndex.parseCCIndexResponse(body);
+            for (let obj of objects) {
+                console.log(obj);
+            }
 
         });
     }

--- a/src/test-runs.ts
+++ b/src/test-runs.ts
@@ -473,7 +473,16 @@ export class TestRuns {
 
     public static testCCIndex() {
         let lookupURL = "http://www.popmech.ru/";
+        CCIndex.getWETPathsForURL(lookupURL, (err, wetPaths) => {
+            if (err) {
+                console.error(err);
+                return;
+            }
+            console.log(wetPaths);
 
+        });
+
+        /*
         CCIndex.lookUpURL(lookupURL, (err, body) => {
             if (err) {
                 console.error(err);
@@ -490,6 +499,8 @@ export class TestRuns {
             console.log(wetPaths);
 
         });
+        */
+
     }
 
 }

--- a/src/test-runs.ts
+++ b/src/test-runs.ts
@@ -7,6 +7,7 @@ import { TermSearch, Occurrence } from "./term-search";
 import { BloomFilter } from "./bloom-filter";
 import {WetManager} from "./wet-manager";
 import {TermLoader} from "./term-loader";
+import {CCIndex} from "./cc-index";
 
 /**
  * Playground for testing.
@@ -448,7 +449,7 @@ export class TestRuns {
 
 
     public static testWetManager() {
-        let url = 'crawl-data/CC-MAIN-2017-09/segments/1487501172017.60/wet/CC-MAIN-20170219104612-00150-ip-10-171-10-108.ec2.internal.warc.wet.gz'
+        let url = 'crawl-data/CC-MAIN-2017-09/segments/1487501172017.60/wet/CC-MAIN-20170219104612-00150-ip-10-171-10-108.ec2.internal.warc.wet.gz';
         let timeStart = new Date().getTime();
         WetManager.loadWetAsStream(url, function(err, result) {
             if(err) {
@@ -467,6 +468,18 @@ export class TestRuns {
                 let timeFinish = new Date().getTime();
                 console.log('Finished. Took ' + (timeFinish - timeStart) + 'ms');
             });
+        });
+    }
+
+    public static testCCIndex() {
+        CCIndex.lookUpURL("https://en.wikipedia.org/wiki/Wolfgang_Amadeus_Mozart", (err, body) => {
+            if (err) {
+                console.error(err);
+                return;
+            }
+
+            console.log("CC Index response body:\n" + body);
+
         });
     }
 

--- a/src/test-runs.ts
+++ b/src/test-runs.ts
@@ -472,17 +472,22 @@ export class TestRuns {
     }
 
     public static testCCIndex() {
-        CCIndex.lookUpURL("https://en.wikipedia.org/wiki/Wolfgang_Amadeus_Mozart", (err, body) => {
+        let lookupURL = "http://www.popmech.ru/";
+
+        CCIndex.lookUpURL(lookupURL, (err, body) => {
             if (err) {
                 console.error(err);
                 return;
             }
 
             console.log("CC Index response body, parsed:\n");
-            let objects = CCIndex.parseCCIndexResponse(body);
+            let objects = CCIndex.parseStringToCCIndexResponse(body);
             for (let obj of objects) {
                 console.log(obj);
             }
+
+            let wetPaths = CCIndex.constructWETPaths(lookupURL, objects);
+            console.log(wetPaths);
 
         });
     }


### PR DESCRIPTION
We now can:
- query CC index for any URL *u*
- get all paths to WET files that contain a page located at *u*
- get one of the files and extract all pages located at *u*

This is implemented in `getWebsiteByURL()` in `test-runs.ts`. We are already using the new `WetManager`, so the second run is much faster.