### PR TITLE
Added WebPageDigester class. Slight modifications to WebPage.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "chai": "^3.5.0"
   },
   "scripts": {
-    "start": "node app.js",
+    "start": "node out/app.js",
     "test": "mocha \"out/test/**/*.js\""
   }
 }

--- a/src/language-extractor.ts
+++ b/src/language-extractor.ts
@@ -1,9 +1,5 @@
-/**
- * Created by Anshul on 3/7/2017.
- */
-
 import {AlreadyExistsError,UnsupportedFileFormat} from './utils/errors';
-import {WebPage} from "./utils/web-page";
+import {WebPage} from "./utils/webpage";
 
 export class LanguageExtractor {
 
@@ -71,7 +67,7 @@ export class LanguageExtractor {
             this.isWebPageInLanguage(page, searchLanguage, function(result : boolean) {
                 if(result) {
                     //console.log('writing entry #' + entryID + '!');
-                    writeStream.write(page.toString());
+                    writeStream.write(page.toWARCString());
                 } else {
                     //console.log('skipping entry #' + entryID + '!');
                 }
@@ -116,7 +112,7 @@ export class LanguageExtractor {
         const testStringMiddleEnd: number = (content.length / 2) + chunkSize < content.length ? (content.length / 2) + chunkSize : content.length;
         const testString = content.substring(0,testStringBeginning) + content.substring(testStringMiddleStart, testStringMiddleEnd) + content.substring(testStringEnding, content.length);
 
-        LanguageExtractor.cld.detect(testString, { isHTML: false,tldHint: page.getTLD()}, function(err, result) {
+        LanguageExtractor.cld.detect(testString, { isHTML: false, tldHint: page.getTLD()}, function(err, result) {
             if(err) {
                 //console.log(err + "page tld: " + page.getTLD());
                 //On the test data only 0.6% pages are not classified, to detect these we can use franc ( execution time increases by only approximately 3% )

--- a/src/sample-data/sample-data-generator.ts
+++ b/src/sample-data/sample-data-generator.ts
@@ -4,7 +4,7 @@ import {Unpacker} from "../unpacker";
 import {CCIndex} from "../cc-index";
 import {WetManager} from "../wet-manager";
 import {TermLoader} from "../utils/term-loader";
-import {WebPage} from "../utils/web-page";
+import {WebPage} from "../utils/webpage";
 import {Occurrence} from "../utils/occurrence";
 import {PrefixTree} from "../filters/prefix-tree";
 
@@ -79,7 +79,7 @@ export class SampleDataGenerator {
                         // if page is good, print to file
                         if (distinctOccs > 4 && totalOccs > 9) {
                             // this page is considered as good
-                            writeStream.write(p.toString());
+                            writeStream.write(p.toWARCString());
 
                             pagesFound++;
                             if (pagesFound > 100) {
@@ -237,7 +237,7 @@ export class SampleDataGenerator {
                                 // write page to file
                                 foundPages++;
                                 console.log("   :)  found relevant page: " + p.getURI());
-                                writeStream.write(p.toString());
+                                writeStream.write(p.toWARCString());
                                 return;
                             }
                         }

--- a/src/storer.ts
+++ b/src/storer.ts
@@ -1,4 +1,4 @@
-import {WebPage} from "./utils/web-page";
+import {WebPage} from "./utils/webpage";
 export class Storer {
 
     static azure = require('azure');
@@ -30,7 +30,7 @@ export class Storer {
                 blobContent += property + ": " + webpage.headers[property] + '\n';
             }
         }
-        blobContent += webpage.content
+        blobContent += webpage.content;
         Storer.blobService.createBlockBlobFromText(Storer.container, blobName, blobContent, function(err, result) {
             if(err) {
                 if(callback) {

--- a/src/test-runs.ts
+++ b/src/test-runs.ts
@@ -1,7 +1,7 @@
 import { Downloader } from "./downloader";
 import { Unpacker } from "./unpacker";
 import { WordPreprocessor } from "./word-preprocessor";
-import { WebPage } from "./utils/web-page";
+import { WebPage } from "./utils/webpage";
 import { LanguageExtractor } from "./language-extractor";
 import { WetManager } from "./wet-manager";
 import { CCIndex } from "./cc-index";

--- a/src/test/utils/webpage-test.ts
+++ b/src/test/utils/webpage-test.ts
@@ -1,0 +1,37 @@
+import "mocha";
+import {WebPage} from "../../utils/webpage";
+let assert = require("chai").assert;
+
+function generateDummyWARC(url : string) : object {
+    return {
+        protocol: "WARC/1.0",
+        headers: {
+            "WARC-Type": "conversion",
+            "WARC-Target-URI": url
+        },
+        content: new Buffer("Some sample text, yay!")
+    };
+}
+
+describe("WebPage", () => {
+    it("should assemble a WebPage into WARC string correctly", () => {
+        let expected = "WARC/1.0" +
+            "\nWARC-Type: conversion" +
+            "\nWARC-Target-URI: https://host.com/a/path.html" +
+            "\n\nSome sample text, yay!" +
+            "\n\n";
+        assert.strictEqual(new WebPage(generateDummyWARC("https://host.com/a/path.html")).toWARCString(), expected);
+    });
+    it("should return empty string as TLD of IPv4 address", () => {
+        let webPage = new WebPage(generateDummyWARC("https://127.0.0.1/a/path.html"));
+        assert.strictEqual(webPage.getTLD(), "");
+    });
+    it("should return empty string as TLD of IPv6 address", () => {
+        let webPage = new WebPage(generateDummyWARC("https://42fa:eab6::1/a/path.html"));
+        assert.strictEqual(webPage.getTLD(), "");
+    });
+    it("should return the correct TLD", () => {
+        let webPage = new WebPage(generateDummyWARC("https://this.host.has.sub.domains.co.uk/meh"));
+        assert.strictEqual(webPage.getTLD(), "uk");
+    })
+});

--- a/src/test/webpage-digester-test.ts
+++ b/src/test/webpage-digester-test.ts
@@ -1,0 +1,54 @@
+import "mocha";
+import {WebPageDigester} from "../webpage-digester";
+import {PrefixTree} from "../filters/prefix-tree";
+import {WebPage} from "../utils/webpage";
+import {BloomFilter} from "../filters/bloom-filter";
+import {NaiveFilter} from "../filters/naive-filter";
+import {Occurrence} from "../utils/occurrence";
+let assert = require("chai").assert;
+
+let terms = ["some", "more", "or", "less", "random", "terms"];
+
+function createDummyWebPage() : WebPage {
+    let webPage = new WebPage();
+    webPage.content = "I am not very creative when writing these tests, like not at all. " +
+        "I should probably add some terms in this text otherwise this test is useless...";
+    return webPage;
+}
+
+describe("WebSiteDigester", () => {
+    it("adding and removing a pre-filter shouldn't change the results", () => {
+        let digester = new WebPageDigester(terms).setFilter(PrefixTree);
+        let before = digester.digest(createDummyWebPage());
+
+        // add pre-filter, digest a webPage with pre-filter and then remove the pre-filter
+        digester.setPreFilter(BloomFilter);
+        digester.digest(createDummyWebPage());
+        digester.removePreFilter();
+
+        let after = digester.digest(createDummyWebPage());
+        assert.deepEqual(after, before);
+    });
+    it("replacing the filter with the same filter shouldn't change the results", () => {
+        let digester = new WebPageDigester(terms).setFilter(NaiveFilter);
+        let before = digester.digest(createDummyWebPage());
+
+        // replace filter twice
+        digester.setFilter(PrefixTree);
+        digester.setFilter(NaiveFilter);
+
+        let after = digester.digest(createDummyWebPage());
+        assert.deepEqual(after, before);
+    });
+    it("should merge occurrences correctly", () => {
+        let webPage = createDummyWebPage();
+        webPage.occurrences = [new Occurrence("terms", [42]), new Occurrence("false positive", [10])];
+
+        let digester = new WebPageDigester(terms).setFilter(NaiveFilter);
+        let result = digester.digest(webPage, true);
+
+        let expected = createDummyWebPage();
+        expected.occurrences = [new Occurrence("terms", [42, 93]), new Occurrence("false positive", [10])];
+        assert(result, expected);
+    });
+});

--- a/src/webpage-digester.ts
+++ b/src/webpage-digester.ts
@@ -1,0 +1,135 @@
+import {IndexFilter} from "./filters/index-filter";
+import {Filter} from "./filters/filter";
+import {WebPage} from "./utils/webpage";
+import {Occurrence} from "./utils/occurrence";
+
+
+export class WebPageDigester {
+    private searchTerms : Array<string>;
+    private mainFilter : new () => IndexFilter;
+    private mainFilterInstance : IndexFilter;
+    private preFilterInstance : Filter;
+
+    constructor(searchTerms : Array<string>) {
+        this.searchTerms = searchTerms;
+    }
+
+    /**
+     * Set the main filter of the digester which will determine the indexes of all matches
+     * Be careful which filter to use here as not all filters will give you exact matches!
+     * @param filterConstructor                             Class of the filter
+     */
+    public setFilter<T extends IndexFilter> (filterConstructor : new () => T) : WebPageDigester {
+        this.mainFilter = filterConstructor;
+        this.mainFilterInstance = undefined;
+        return this;
+    }
+
+    /**
+     * Set a pre-filter which will reduce the number of searchTerms for the main filter
+     * If the pre-filter doesn't find any matches it will skip the main filter entirely
+     * This is very useful if your main filter is slow
+     * @param filterConstructor                             Class of the pre-filter
+     */
+    public setPreFilter<T extends Filter> (filterConstructor : new () => T) : WebPageDigester{
+        this.preFilterInstance = new filterConstructor();
+        this.preFilterInstance.addSearchTerms(this.searchTerms);
+        return this;
+    }
+
+    public removePreFilter() : WebPageDigester {
+        // remove references to both instances as current mainFilterInstance is NOT independent form preFilter
+        this.preFilterInstance = undefined;
+        this.mainFilterInstance = undefined;
+        return this;
+    }
+
+    /**
+     * Adds Occurrences to a WebPage object. First applies a preFilter if set, to find matches
+     * and then applies the mainFilter to its output to find the exact positions within the text.
+     * If no preFilter is set, the mainFilter will be fed with all searchTerms.
+     * @param webPage                                       WebPage object to find occurrences in.
+     * @param mergeOccurrences                              When true occurrences will be merged instead of overwritten
+     * @return {WebPage}                                    Reference to the same WebPage with added occurrences
+     */
+    public digest(webPage : WebPage, mergeOccurrences? : boolean) : WebPage {
+
+        if(!this.mainFilter) {
+            console.warn("Couldn't apply any filters as filter isn't set! Set a filter with .setFilter()!");
+            return webPage;
+        }
+
+        let pageContent = webPage.content;
+
+        // use preFilter if present
+        if (this.preFilterInstance) {
+            // find all matches, but ignore the match indexes for now
+            let matches = this.preFilterInstance.getMatches(pageContent);
+
+            // Stop here if there aren't any matches.
+            if (matches.size === 0) {
+                return webPage;
+            }
+
+            // create new IndexFilter instance from matched searchTerms
+            this.mainFilterInstance = new this.mainFilter();
+            this.mainFilterInstance.addSearchTerms([...matches]); // [... Set] operator converts Set to Array
+        }
+
+        // create new mainFilterInstance from this.searchTerms if not present
+        if (!this.mainFilterInstance) {
+            this.mainFilterInstance = new this.mainFilter();
+            this.mainFilterInstance.addSearchTerms(this.searchTerms);
+        }
+
+        let occurrences = this.mainFilterInstance.getMatchesIndex(pageContent);
+
+        // check if we have to merge occurrences and update webPage object
+        if (mergeOccurrences && webPage.occurrences && occurrences.length > 0 && webPage.occurrences.length > 0) {
+
+            // merge occurrences
+            webPage.occurrences = WebPageDigester.mergeOccurrences(occurrences, webPage.occurrences);
+
+        } else {
+
+            // overwrite occurrences
+            webPage.occurrences = occurrences
+        }
+
+        return webPage;
+    }
+
+    /**
+     * [HELPER FUNCTION] Deeply merges two arrays of Occurrences into a single one
+     * @param occ1
+     * @param occ2
+     * @return {Array<Occurrence>}
+     */
+    private static mergeOccurrences(occ1 : Array<Occurrence>, occ2 : Array<Occurrence>) : Array<Occurrence> {
+
+        // convert one of the arrays into Map
+        let mergedOccurrencesMap = Occurrence.occurrenceArrayToMap(occ1);
+
+        // add new occurrences one by one to the map
+        for (let occurrence of occ2) {
+
+            // check if term is already present in map
+            if (mergedOccurrencesMap.has(occurrence.term)) {
+
+                // merge indexes, convert already present indexes to map
+                let mergedIndexes = new Set(mergedOccurrencesMap.get(occurrence.term));
+                for (let index of occurrence.positions) {
+                    mergedIndexes.add(index);
+                }
+                mergedOccurrencesMap.set(occurrence.term, [...mergedIndexes]);
+
+            } else {
+                mergedOccurrencesMap.set(occurrence.term, occurrence.positions);
+            }
+
+        }
+
+        // convert map back to an array of Occurrences
+        return Occurrence.occurrenceMapToArray(mergedOccurrencesMap);
+    }
+}

--- a/src/wet-manager.ts
+++ b/src/wet-manager.ts
@@ -30,7 +30,7 @@ export class WetManager {
     public static loadWetAsStream(filename : string, callback : (err? : Error, resp? : ReadableStream) => void,
         useCaching : boolean = true) : void {
         //URL address of file on server
-        let url = WetManager.basePath + filename;
+        let url = WetManager.path.join(WetManager.basePath, filename);
         if (useCaching) {
             WetManager.openWithCaching(url, callback);
         } else {

--- a/src/word-preprocessor.ts
+++ b/src/word-preprocessor.ts
@@ -1,4 +1,4 @@
-import {WebPage} from "./utils/web-page";
+import {WebPage} from "./utils/webpage";
 export class WordPreprocessor {
 
     static snowball = require('node-snowball');


### PR DESCRIPTION
- Added `WebPageDigester` class for adding occurrences to `WebPage` objects. It will filter the content of a passed `WebPage` for search term occurrences with the set filter and optional pre-filter. The result will be added to the passed `WebPage` object. Occurrences can be merged (with optional parameter `mergeOccurrences`) or overwritten.

**USAGE:**
```
import {WebPageDigester} from "../webpage-digester";
import {PrefixTree} from "../filters/prefix-tree";
import {WebPage} from "../utils/webpage";

let terms = ["some", "terms"];
let digester = new WebPageDigester(terms).setFilter(PrefixTree);
digester.digest(new WebPage());
```
Allows changing and removing filters and method chaining:
```
let digester = new WebPageDigester(terms)
    .setFilter(PrefixTree)
    .setPreFilter(BloomFilter)
    .removePreFilter()
    .setPreFilter(PrefixTree)
    .setFilter(NaiveFilter);
```

- Reworked `.getTLD()` in `WebPage`, added `occurrence` property and made constructor parameter optional

- Added UNIT tests for `WebPageDigester` and `WebPage`

- Renamed `web-page.ts` to `webpage.ts`