### PR TITLE
Removed overhead when converting from Sets to Arrays and back.

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,3 @@
 // TEST RUNS
 // Don't run multiple runs simultaneously!
 import {TestRuns} from "./test-runs";
-
-

--- a/src/filters/bloom-filter.ts
+++ b/src/filters/bloom-filter.ts
@@ -6,10 +6,17 @@ export class BloomFilter extends Filter{
     private static ERROR_RATE = 0.1;
     private filter;
 
-    constructor(tokens? : string[]) {
-        super();
+    /**
+     * Replaces constructor and gets called by the super class constructor
+     * @param searchTerms           search terms to initialize filter with
+     */
+    protected init(searchTerms : Set<string>) : void {
         this.filter = new BloomFilter.bloem.ScalingBloem(BloomFilter.ERROR_RATE);
-        if(tokens){ super.addSearchTerms(tokens); }
+        if(searchTerms){
+            for (let term of searchTerms) {
+                this.addSearchTerm(term);
+            }
+        }
     }
 
     /**

--- a/src/filters/filter.ts
+++ b/src/filters/filter.ts
@@ -1,14 +1,24 @@
 export abstract class Filter {
 
+    constructor(searchTerms? : Set<string>) {
+        this.init(searchTerms);
+    }
+
     /**
-     * @param token                token to add to the filter
+     * Replaces constructor and gets called by the super class constructor
+     * @param searchTerms           search terms to initialize filter with
+     */
+    protected abstract init(searchTerms : Set<string>) : void;
+
+    /**
+     * @param token                 token to add to the filter
      */
     abstract addSearchTerm(token : string) : void;
 
     /**
-     * @param tokens                array of tokens to add to the filter
+     * @param tokens                Set of tokens to add to the filter
      */
-    public addSearchTerms(tokens : string[]) : void {
+    public addSearchTerms(tokens : Set<string>) : void {
         for (let token of tokens){
             this.addSearchTerm(token);
         }

--- a/src/filters/naive-filter.ts
+++ b/src/filters/naive-filter.ts
@@ -5,10 +5,17 @@ export class NaiveFilter extends IndexFilter {
     private static tokenizer = new (require('natural')).WordTokenizer();
     private searchTerms : Set<string>;
 
-    constructor(terms? : Array<string>) {
-        super();
+    /**
+     * Replaces constructor and gets called by the super class constructor
+     * @param searchTerms           search terms to initialize filter with
+     */
+    protected init(searchTerms : Set<string>) : void {
         this.searchTerms = new Set();
-        if (terms) { this.searchTerms = new Set(terms); }
+        if(searchTerms){
+            for (let term of searchTerms) {
+                this.addSearchTerm(term);
+            }
+        }
     }
 
     /**

--- a/src/filters/prefix-tree.ts
+++ b/src/filters/prefix-tree.ts
@@ -19,13 +19,16 @@ export class PrefixTree extends IndexFilter{
     private root : PTElement;
 
     /**
-     * Create a PrefixTree and add initialize it with a set of terms (optional).
-     * @param tokens
+     * Replaces constructor and gets called by the super class constructor
+     * @param searchTerms           search terms to initialize filter with
      */
-    constructor(tokens? : string[]) {
-        super();
+    protected init(searchTerms : Set<string>) : void {
         this.root = new PTNode(); // not a leaf! we do not want to match any string!
-        if (tokens) { super.addSearchTerms(tokens); }
+        if(searchTerms){
+            for (let term of searchTerms) {
+                this.addSearchTerm(term);
+            }
+        }
     }
 
     /**

--- a/src/sample-data/sample-data-generator.ts
+++ b/src/sample-data/sample-data-generator.ts
@@ -33,7 +33,7 @@ export class SampleDataGenerator {
 
         // some hardcoded composers here
         let terms = TermLoader.loadDummyTerms();
-        let filter = new PrefixTree(terms);
+        let filter = new PrefixTree(new Set(terms));
         let outputFile = SampleDataGenerator.dataFolder + SampleDataGenerator.fileName_unpacked + "_filtered";
         const writeStream = LanguageExtractor.fs.createWriteStream(outputFile, {flags: 'w'});
         let pagesFound = 0;

--- a/src/test/filters/filter-test.ts
+++ b/src/test/filters/filter-test.ts
@@ -10,41 +10,37 @@ testFilter(BloomFilter);
 testFilter(PrefixTree);
 testFilter(NaiveFilter);
 
-function testFilter<T extends Filter> (filterConstructor : new () => T) {
+function testFilter<T extends Filter> (filterConstructor : new (searchTerms? : Set<string>) => T) {
     let filter : T;
     let filterName = new filterConstructor().constructor.name;
 
     describe("Filter: " + filterName, () => {
         it("should have a match .hasMatch()", () => {
-            filter = new filterConstructor();
             let searchTerms = ['test', 'some', 'random', 'words'];
             let text = 'This is a not so long text which should contain some words.';
-            filter.addSearchTerms(searchTerms);
+            filter = new filterConstructor(new Set(searchTerms));
             let result = filter.hasMatch(text);
             assert.strictEqual(result, true);
         });
         it("should not have a match .hasMatch()", () => {
-            filter = new filterConstructor();
             let searchTerms = ['test', 'sometimes', 'random'];
             let text = 'This is a not so long text which should contain some words.';
-            filter.addSearchTerms(searchTerms);
+            filter = new filterConstructor(new Set(searchTerms));
             let result = filter.hasMatch(text);
             assert.strictEqual(result, false);
         });
         it("should have at least one match, pre- and suffixes might match .getMatches()", () => {
-            filter = new filterConstructor();
             let searchTerms = ['test', 'some', 'random', 'words'];
             let text = 'Sometimes I wonder what I am doing here with all these random tests...';
-            filter.addSearchTerms(searchTerms);
+            filter = new filterConstructor(new Set(searchTerms));
             let result = filter.getMatches(text);
             assert.ok(result.size > 0);
         });
         it("should only have one match .getMatches()", () => {
-            filter = new filterConstructor();
             let searchTerms = ['test', 'some', 'random', 'words'];
             let text = 'There are a not so many words here... Well, let\'s add a few more, just to be sure. ' +
                 'It should only have one match though!';
-            filter.addSearchTerms(searchTerms);
+            filter = new filterConstructor(new Set(searchTerms));
             let result = filter.getMatches(text);
             let expectedResult = new Set(['words']);
             assert.deepEqual(result, expectedResult);

--- a/src/test/filters/index-filter-test.ts
+++ b/src/test/filters/index-filter-test.ts
@@ -9,25 +9,23 @@ let assert = require("chai").assert;
 testFilter(PrefixTree);
 testFilter(NaiveFilter);
 
-function testFilter<T extends IndexFilter> (filterConstructor : new () => T) {
+function testFilter<T extends IndexFilter> (filterConstructor : new (searchTerms? : Set<string>) => T) {
     let filter : T;
     let filterName = new filterConstructor().constructor.name;
 
     describe("IndexFilter: " + filterName, () => {
         it("should have at least one match, pre- and suffixes are allowed .getMatchesIndex()", () => {
-            filter = new filterConstructor();
             let searchTerms = ['test', 'some', 'random', 'words'];
             let text = 'Sometimes I wonder what I am doing here with all these random tests...';
-            filter.addSearchTerms(searchTerms);
+            filter = new filterConstructor(new Set(searchTerms));
             let result = filter.getMatchesIndex(text);
             assert.ok(result.length > 0);
         });
         it("should only have one match .getMatchesIndex()", () => {
-            filter = new filterConstructor();
             let searchTerms = ['test', 'some', 'random', 'words'];
             let text = 'There are a not so many words here... Well, let\'s add a few more, just to be sure. ' +
                 'It should only have one match though!';
-            filter.addSearchTerms(searchTerms);
+            filter = new filterConstructor(new Set(searchTerms));
             let result = filter.getMatchesIndex(text);
             let expectedResult = [new Occurrence('words', [24])];
             assert.deepEqual(result, expectedResult);


### PR DESCRIPTION
- Removed overhead when converting from Sets to Arrays and back.

@nyxathid we still have to call `.addSearchTerm()` in `NaiveFilter` for every search term as this will ensure us that all search terms are in lower case. We're actually creating a copy of the search terms and aren't referencing an object which can be modified by other sources. I rather have it run slightly slower than wasting lots of hours debugging.