### PR TITLE
Read artists from db

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,11 @@
-// TEST RUNS
-// Don't run multiple runs simultaneously!
-import {TestRuns} from "./test-runs";
+import {TermLoader} from "./utils/term-loader";
+
+TermLoader.loadFromDB((err, entities) => {
+    if (err) {
+        console.log("SHIT!\n", err);
+        return;
+    }
+    console.log("\n\n\n\n");
+    console.log("entities:\n", entities);
+
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     ]
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "api"
   ]
 }


### PR DESCRIPTION
Done in this PR:
- Set the api submodule to be ignored by TypeScript compiler. No need to compile all node modules and get strange errors.
- Implemented DB access in `TermLoader`: right now we are only reading artist names

A way to test is:
- clone StructuredData git
- init & update the API submodule in StructuredData (should have been fixed to the newest version today)
- Install PostgreSQL locally (use settings from `StructuredData/api/config.js.template`)
- run `node cli.js -s test` inside StructuredData to populate the DB
- install `pgAdmin` and take a look at the DB, optional: add a new entity and a composer
- update the API submodule in UNStructuredData
- run `app.ts`, it should print some DB log stuff followed by an array of Entities: `[ Entity {term: 'Frank', id: '...'}, ... ]`