### PR TITLE
Passing parameters to workers and redefining responsibility of CLI class

### DIFF
--- a/configsample.json
+++ b/configsample.json
@@ -15,6 +15,6 @@
 	"blobAccount": "wetstorage",
 	"blobContainer": "websites",
 	"blobKey": "<your azure key here>",
-	"threads": null,
+	"processes": null,
 	"crawlVersion": "CC-MAIN-2017-13"
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,12 +8,6 @@
 
 import {ProcessingManager} from "./processing-manager";
 import {Worker} from "./worker";
-import {CLI} from "./cli";
-
-
-CLI.initCLI();
-CLI.logParms(); // will hide sensitive parameters, never log CLI.parameters directly!
-
 
 // Don't touch this otherwise Felix will kill you :P
 ProcessingManager.run();

--- a/src/cc-index.ts
+++ b/src/cc-index.ts
@@ -241,6 +241,7 @@ export class CCIndex {
 
         lookupURL = lookupURL.replace("https://", "").replace("http://", ""); // remove http(s)
         let indexPage = ccIndexPageURL || this.defaultCCIndex;
+        if (!indexPage) callback(new TypeError("No CC index page was supplied!"));
 
         let query = indexPage + "?url=" + encodeURI(lookupURL) + "&output=json";
 

--- a/src/cc-index.ts
+++ b/src/cc-index.ts
@@ -1,5 +1,4 @@
 import {Downloader} from "./downloader";
-import {CLI} from "./cli";
 
 /**
  * Objects of this class represent responses from the CommonCrawl index.
@@ -29,10 +28,7 @@ export class CCIndex {
     public defaultCCIndex : string;
 
     constructor(crawlVersion? : string) {
-        if (!crawlVersion) {
-            crawlVersion = CLI.parameters.crawlVersion;
-        }
-        this.defaultCCIndex = "http://index.commoncrawl.org/" + crawlVersion + "-index";
+        this.defaultCCIndex = crawlVersion ? "http://index.commoncrawl.org/" + crawlVersion + "-index" : undefined;
     }
 
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,17 @@
-class CLI {
+export class CLI {
 
-    private static commander = require('commander');
+    private static instance : CLI;
 
-    public static parameters = {
+    public static getInstance() : CLI {
+        if (!CLI.instance) {
+            CLI.instance = new CLI();
+        }
+        return CLI.instance
+    }
+
+    private commander = require('commander');
+
+    public parameters = {
         wetFrom: undefined,
         wetTo: undefined,
         dbHost: undefined,
@@ -19,10 +28,10 @@ class CLI {
     /**
      * Init the commander module, parse env variables, config file and command line args.
      */
-    public static init() {
+    private constructor() {
 
         // init commander
-        CLI.commander
+        this.commander
             .option('-w, --wet-range [start]:[end]', 'the subset of WET files to process, e.g. "0:99"')
             .option('-d, --db-location [host]:[port]', 'database location, e.g. "127.0.0.1:5432"')
             .option('-a, --db-access [user]:[password]', 'database access, e.g. "USER:PASSWORD"')
@@ -33,75 +42,69 @@ class CLI {
             .parse(process.argv);
 
 
-        CLI.parseCmdOptions();
+        this.parseCmdOptions();
 
     }
-
 
     /**
      * Parse command line arguments and store values in CLI.parameters
      */
-    private static parseCmdOptions() {
+    private parseCmdOptions() {
 
-        if (CLI.commander.wetRange) {
-            if (!CLI.commander.wetRange.split) {
+        if (this.commander.wetRange) {
+            if (!this.commander.wetRange.split) {
                 console.warn("invalid --wet-range [start]:[end]");
             } else {
-                let splitted = CLI.commander.wetRange.split(":", 2);
+                let splitted = this.commander.wetRange.split(":", 2);
                 let wetFrom = parseInt(splitted[0]);
                 let wetTo = parseInt(splitted[1]);
-                if (wetFrom) CLI.parameters.wetFrom = wetFrom;
-                if (wetTo)   CLI.parameters.wetTo = wetTo;
+                if (wetFrom) this.parameters.wetFrom = wetFrom;
+                if (wetTo)   this.parameters.wetTo = wetTo;
             }
         }
 
-        if (CLI.commander.dbLocation) {
-            if (!CLI.commander.dbLocation.split) {
+        if (this.commander.dbLocation) {
+            if (!this.commander.dbLocation.split) {
                 console.warn("invalid --db-location [host]:[port]");
             } else {
-                let splitted = CLI.commander.dbLocation.split(":", 2);
-                CLI.parameters.dbHost = splitted[0];
+                let splitted = this.commander.dbLocation.split(":", 2);
+                this.parameters.dbHost = splitted[0];
                 let dbPort = parseInt(splitted[1]);
-                if (dbPort) CLI.parameters.dbPort = dbPort;
+                if (dbPort) this.parameters.dbPort = dbPort;
             }
         }
 
-        if (CLI.commander.dbAccess) {
-            if (!CLI.commander.dbAccess.split) {
+        if (this.commander.dbAccess) {
+            if (!this.commander.dbAccess.split) {
                 console.warn("invalid --db-access [user]:[password]");
             } else {
-                let splitted = CLI.commander.dbAccess.split(":", 2);
-                CLI.parameters.dbUser = splitted[0];
-                CLI.parameters.dbPW = splitted[1];
+                let splitted = this.commander.dbAccess.split(":", 2);
+                this.parameters.dbUser = splitted[0];
+                this.parameters.dbPW = splitted[1];
             }
         }
 
-        if (CLI.commander.blobLocation) {
-            if (!CLI.commander.blobLocation.split) {
+        if (this.commander.blobLocation) {
+            if (!this.commander.blobLocation.split) {
                 console.warn("invalid --blob-location [account]:[container]");
             } else {
-                let splitted = CLI.commander.blobLocation.split(":", 2);
-                CLI.parameters.blobAccount = splitted[0];
-                CLI.parameters.blobContainer = splitted[1];
+                let splitted = this.commander.blobLocation.split(":", 2);
+                this.parameters.blobAccount = splitted[0];
+                this.parameters.blobContainer = splitted[1];
             }
         }
 
-        if (CLI.commander.blobKey) {
-            CLI.parameters.blobKey = CLI.commander.blobKey;
+        if (this.commander.blobKey) {
+            this.parameters.blobKey = this.commander.blobKey;
         }
 
-        if (CLI.commander.processes) {
-            let threads = parseInt(CLI.commander.processes);
-            if (threads) CLI.parameters.processes = threads;
+        if (this.commander.processes) {
+            let threads = parseInt(this.commander.processes);
+            if (threads) this.parameters.processes = threads;
         }
 
-        if (CLI.commander.crawl) {
-            CLI.parameters.crawlVersion = CLI.commander.crawl;
+        if (this.commander.crawl) {
+            this.parameters.crawlVersion = this.commander.crawl;
         }
     }
 }
-
-export let params = function () {
-    CLI.init();
-    return CLI.parameters;
-}();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,33 +1,25 @@
-import * as os from "os";
-
-export class CLI {
+class CLI {
 
     private static commander = require('commander');
 
-    // runtime parameters, default values
     public static parameters = {
-        wetFrom: 0,
-        wetTo: 999999,
-        dbHost: "13.74.11.216",
-        dbPort: 5432,
-        dbUser: "privateStuff",
-        dbPW: "privateStuff",
-        blobAccount: "wetstorage",
-        blobContainer: "websites",
-        blobKey: "privateStuff",
-        threads: os.cpus().length,
-        crawlVersion: "CC-MAIN-2017-13"
+        wetFrom: undefined,
+        wetTo: undefined,
+        dbHost: undefined,
+        dbPort: undefined,
+        dbUser: undefined,
+        dbPW: undefined,
+        blobAccount: undefined,
+        blobContainer: undefined,
+        blobKey: undefined,
+        processes: undefined,
+        crawlVersion: undefined
     };
-
-    // these parameters will not be logged
-    private static privateParms = new Set([
-        "dbPW", "blobKey"
-    ]);
 
     /**
      * Init the commander module, parse env variables, config file and command line args.
      */
-    public static initCLI() {
+    public static init() {
 
         // init commander
         CLI.commander
@@ -41,36 +33,15 @@ export class CLI {
             .parse(process.argv);
 
 
-        // environment variables override default hardcoded values
-        CLI.parseEnvVars();
-        // config overrides environment vars
-        CLI.parseConfigFile();
-        // command line overrides all
         CLI.parseCmdOptions();
 
     }
 
-    /**
-     * Load parameters from environment variables.
-     */
-    public static parseEnvVars() {
-        // TODO: replace default values in CLI.parameters with environment variables
-    }
-
-    /**
-     * Load parameters from "config.json".
-     */
-    public static parseConfigFile() {
-        let configFile = require('../config.json');
-        for (let parm in CLI.parameters) {
-            if (configFile[parm]) CLI.parameters[parm] = configFile[parm];
-        }
-    }
 
     /**
      * Parse command line arguments and store values in CLI.parameters
      */
-    public static parseCmdOptions() {
+    private static parseCmdOptions() {
 
         if (CLI.commander.wetRange) {
             if (!CLI.commander.wetRange.split) {
@@ -119,29 +90,18 @@ export class CLI {
             CLI.parameters.blobKey = CLI.commander.blobKey;
         }
 
-        if (CLI.commander.threads) {
-            let threads = parseInt(CLI.commander.threads);
-            if (threads) CLI.parameters.threads = threads;
+        if (CLI.commander.processes) {
+            let threads = parseInt(CLI.commander.processes);
+            if (threads) CLI.parameters.processes = threads;
         }
 
         if (CLI.commander.crawl) {
             CLI.parameters.crawlVersion = CLI.commander.crawl;
         }
-
     }
-
-    /**
-     * Log CLI.parameters, sensitive parameters will be hidden.
-     */
-    public static logParms() {
-        console.log("Runtime parameters:");
-        for (let parm in CLI.parameters) {
-            if (!CLI.privateParms.has(parm)) {
-                console.log("\t" + parm + " = " + CLI.parameters[parm]);
-            } else {
-                console.log("\t" + parm + " = [HIDDEN]");
-            }
-        }
-    }
-
 }
+
+export let params = function () {
+    CLI.init();
+    return CLI.parameters;
+}();

--- a/src/processing-manager.ts
+++ b/src/processing-manager.ts
@@ -3,7 +3,7 @@ import * as os from "os";
 import {TermLoader} from "./utils/term-loader";
 import {Term} from "./utils/term";
 import {CCPathLoader} from "./utils/cc-path-loader";
-import * as CLI from "./cli";
+import {CLI} from "./cli";
 
 
 /**
@@ -108,7 +108,7 @@ export class ProcessingManager {
     }
 
     private static getParam(param : string) {
-        return CLI.params[param] || ProcessingManager.CONFIG_FILE[param]
+        return CLI.getInstance().parameters[param] || ProcessingManager.CONFIG_FILE[param]
             || process.env[param] || ProcessingManager.DEFAULTS[param]
     }
 

--- a/src/processing-manager.ts
+++ b/src/processing-manager.ts
@@ -58,6 +58,23 @@ export class ProcessingManager {
         };
 
         let spawnProcesses = () => {
+
+            const workerParams = {
+                terms: terms,
+                languageCodes: undefined,
+                caching: false,
+                blobParams: {
+                    "blobAccount": ProcessingManager.getParam("blobAccount"),
+                    "blobContainer": ProcessingManager.getParam("blobContainer"),
+                    "blobKey": ProcessingManager.getParam("blobKey")
+                },
+                dbParams: {
+                    "dbHost": ProcessingManager.getParam("dbHost"),
+                    "dbPort": ProcessingManager.getParam("dbPort"),
+                    "dbUser": ProcessingManager.getParam("dbUser"),
+                    "dbPW": ProcessingManager.getParam("dbPW")
+                }
+            };
             for (let i = 0; i < ProcessingManager.getParam("processes"); i++) {
 
                 let worker = cluster.fork();
@@ -80,22 +97,7 @@ export class ProcessingManager {
 
                 // init worker
                 worker.send({
-                    init: {
-                        terms: terms,
-                        languageCodes: undefined,
-                        caching: false,
-                        blobParams: {
-                            "blobAccount": ProcessingManager.getParam("blobAccount"),
-                            "blobContainer": ProcessingManager.getParam("blobContainer"),
-                            "blobKey": ProcessingManager.getParam("blobKey")
-                        },
-                        dbParams: {
-                            "dbHost": ProcessingManager.getParam("dbHost"),
-                            "dbPort": ProcessingManager.getParam("dbPort"),
-                            "dbUser": ProcessingManager.getParam("dbUser"),
-                            "dbPW": ProcessingManager.getParam("dbPW")
-                        }
-                    }
+                    init: workerParams
                 });
 
                 console.log("[MASTER] successfully spawned a worker process!");

--- a/src/storer.ts
+++ b/src/storer.ts
@@ -1,6 +1,5 @@
 import {WebPage} from "./utils/webpage";
 import {Unpacker} from "./unpacker";
-import {CLI} from "./cli";
 export class Storer {
 
     static azure = require('azure');
@@ -15,7 +14,7 @@ export class Storer {
     //This could be left out but it makes it easier for the other groups to access the blobs if we store them with fqdn
     private blobPrefix : string;
 
-    constructor(){
+    constructor(blobAccount : string, blobContainer : string, blobKey : string){
         //Connect to database using api's index
         require('../api/database').connect(null, context => {
             //Store context
@@ -28,36 +27,36 @@ export class Storer {
             context.sequelize.sync().then(() => {return this;});
         });
         this.blobService = Storer.azure.createBlobService(
-            CLI.parameters.blobAccount,
-            CLI.parameters.blobKey
+            blobAccount,
+            blobKey
         );
-        this.blobPrefix = 'https://' + CLI.parameters.blobAccount +
-            '.blob.core.windows.net/' + CLI.parameters.blobContainer + '/';
-        this.container = CLI.parameters.blobContainer
+        this.blobPrefix = 'https://' + blobAccount +
+            '.blob.core.windows.net/' + blobContainer + '/';
+        this.container = blobContainer;
     }
 
     /**
      * Stores the website in the Azure blob and in the DB.
-     * @param webpage
+     * @param webPage
      * @param callback
      */
-    public storeWebsite(webpage : WebPage, callback? : (err? : Error) => void ) : void {
-        this.storeWebsiteBlob(webpage, (err, blobName) => {
+    public storeWebsite(webPage : WebPage, callback? : (err? : Error) => void ) : void {
+        this.storeWebsiteBlob(webPage, (err, blobName) => {
             if(err) {
                 if(callback) {
                     callback(err);
                 }
                 return;
             }
-            return this.storeWebsiteMetadata(webpage, this.blobPrefix + blobName, callback); // TODO: why return here? @Lukas
+            return this.storeWebsiteMetadata(webPage, this.blobPrefix + blobName, callback); // TODO: why return here? @Lukas
         });
     }
 
 
-    public storeWebsiteMetadata(webpage : WebPage, blobUrl : string, callback? : (err? : Error) => void) : void{
-        console.log(webpage.getURI());
+    public storeWebsiteMetadata(webPage : WebPage, blobUrl : string, callback? : (err? : Error) => void) : void{
+        console.log(webPage.getURI());
         let websiteObj = {
-            url: webpage.getURI(),
+            url: webPage.getURI(),
             blob_url: blobUrl
         };
 
@@ -69,8 +68,8 @@ export class Storer {
             let containsObjList = [];
 
             //Collect all the contains entries that should be created (One for each term)
-            for(let i = 0; i < webpage.occurrences.length; i++) {
-                let occ = webpage.occurrences[i];
+            for(let i = 0; i < webPage.occurrences.length; i++) {
+                let occ = webPage.occurrences[i];
 
                 containsObjList.push({
                     occurrences: JSON.stringify({
@@ -106,12 +105,12 @@ export class Storer {
      * Stores given website as a blob in the azure blob storage. The filename will be an md5 hash
      * of website uri + content.
      *
-     * @param webpage       WebPage object to be stored
+     * @param webPage       WebPage object to be stored
      * @param callback      Optional callback param that will receive the filename as a parameter in case of success
      */
-    public storeWebsiteBlob(webpage : WebPage, callback? : (err? : Error, blobName? : string) => void) : void {
-        let blobName = Storer.hashWebsite(webpage);
-        let blobContent = webpage.toWARCString();
+    public storeWebsiteBlob(webPage : WebPage, callback? : (err? : Error, blobName? : string) => void) : void {
+        let blobName = Storer.hashWebsite(webPage);
+        let blobContent = webPage.toWARCString();
 
         Unpacker.compressStringToBuffer(blobContent, (err, compressedBlobContent) => {
             if (err) {
@@ -133,8 +132,8 @@ export class Storer {
 
     }
 
-    private static hashWebsite(webpage : WebPage) : string {
+    private static hashWebsite(webPage : WebPage) : string {
         let md5sum = Storer.crypto.createHash('md5');
-        return md5sum.update(webpage.getURI() + webpage.content).digest('hex');
+        return md5sum.update(webPage.getURI() + webPage.content).digest('hex');
     }
 }

--- a/src/test-runs.ts
+++ b/src/test-runs.ts
@@ -21,6 +21,7 @@ export class TestRuns {
     //static rwStream = require("read-write-stream");
 
     static dataFolder = './data/';
+    static config = require("../config.json");
 
     //Feb 17 Crawl data which contains https://www.britannica.com/topic/Chaconne-by-Bach
     static crawlBaseUrl = 'https://commoncrawl.s3.amazonaws.com/crawl-data/CC-MAIN-2017-09/segments/1487501172017.60/wet/';
@@ -198,7 +199,11 @@ export class TestRuns {
 
     public static testStorer() {
         let url = 'crawl-data/CC-MAIN-2017-09/segments/1487501172017.60/wet/CC-MAIN-20170219104612-00150-ip-10-171-10-108.ec2.internal.warc.wet.gz';
-        let storer = new Storer("blobAccount", "blobContainer", "blobKey");
+        let storer = new Storer(
+            TestRuns.config["blobAccount"],
+            TestRuns.config["blobContainer"],
+            TestRuns.config["blobKey"]
+        );
         WetManager.loadWetAsStream(url, function(err, result) {
             if(err) {
                 console.log(err);
@@ -246,7 +251,11 @@ export class TestRuns {
         };
 
         // store on azure (storer will compress it)
-        let storer = new Storer("blobAccount", "blobContainer", "blobKey");
+        let storer = new Storer(
+            TestRuns.config["blobAccount"],
+            TestRuns.config["blobContainer"],
+            TestRuns.config["blobKey"]
+        );
         storer.storeWebsiteBlob(w, (err, blobName) => {
             if (err) {
                 console.log(err);

--- a/src/test-runs.ts
+++ b/src/test-runs.ts
@@ -6,7 +6,7 @@ import { LanguageExtractor } from "./language-extractor";
 import { WetManager } from "./wet-manager";
 import { CCIndex } from "./cc-index";
 import { Storer } from "./storer";
-import {CLI} from "./cli";
+
 
 /**
  * Playground for testing.
@@ -198,7 +198,7 @@ export class TestRuns {
 
     public static testStorer() {
         let url = 'crawl-data/CC-MAIN-2017-09/segments/1487501172017.60/wet/CC-MAIN-20170219104612-00150-ip-10-171-10-108.ec2.internal.warc.wet.gz';
-        let storer = new Storer();
+        let storer = new Storer("blobAccount", "blobContainer", "blobKey");
         WetManager.loadWetAsStream(url, function(err, result) {
             if(err) {
                 console.log(err);
@@ -246,7 +246,7 @@ export class TestRuns {
         };
 
         // store on azure (storer will compress it)
-        let storer = new Storer();
+        let storer = new Storer("blobAccount", "blobContainer", "blobKey");
         storer.storeWebsiteBlob(w, (err, blobName) => {
             if (err) {
                 console.log(err);
@@ -295,7 +295,5 @@ export class TestRuns {
 
     }
 }
-
-CLI.initCLI();
 
 TestRuns.testCCIndex();

--- a/src/test-runs.ts
+++ b/src/test-runs.ts
@@ -184,7 +184,7 @@ export class TestRuns {
         let lookupURL = "https://github.com/";
         console.log("looking up: " + lookupURL);
 
-        const ccIndex = new CCIndex();
+        const ccIndex = new CCIndex(TestRuns.config["crawlVersion"]);
         ccIndex.getWETPathsForURL(lookupURL, (err, wetPaths) => {
             if (err) {
                 console.error(err);


### PR DESCRIPTION
**UNTESTED CHANGES!!!**

- `CLI` class got reduced to command line functionality only! It's `ProcessingManager`'s responsibility to load the `config.json` file as well as handling environment variables and default values.

- The CLI module doesn't export the `CLI` class anymore, but instead the already parsed values

- `ProcessingManager` now passes parameters to `Worker`s

- `ProcessingManager` got a slight face lift **\*yay\***

- Now `wetFrom`, `wetTo` and `crawlVersion` parameters actually have an effect on the application

**UNTESTED CHANGES!!!**