### PR TITLE
Moved db connection to processing-manager.

### DIFF
--- a/src/processing-manager.ts
+++ b/src/processing-manager.ts
@@ -62,7 +62,15 @@ export class ProcessingManager {
             }
         };
 
-        CCPathLoader.loadPaths(undefined, onPaths);
+        let databaseURI = "postgresql://"
+            + CLI.parameters.dbUser + ":"
+            + CLI.parameters.dbPW + "@"
+            + CLI.parameters.dbHost + ":"
+            + CLI.parameters.dbPort + "/mcm";
+
+        require('../api/database').connect(databaseURI, () => {
+            CCPathLoader.loadPaths(undefined, onPaths);
+        });
 
     }
 }

--- a/src/storer.ts
+++ b/src/storer.ts
@@ -17,16 +17,8 @@ export class Storer {
 
     constructor(){
         //Connect to database using api's index
-        require('../api/database').connect(null, context => {
-            //Store context
-            this.context = context;
-            /*
-             Make sure that syncing to database is synchronous.
-             Not that there is no {force: true} option here: We don't want to overwrite
-             existing tables.
-             */
-            context.sequelize.sync().then(() => {return this;});
-        });
+        this.context = require('../api/database').getContext();
+
         this.blobService = Storer.azure.createBlobService(
             CLI.parameters.blobAccount,
             CLI.parameters.blobKey

--- a/src/utils/term-loader.ts
+++ b/src/utils/term-loader.ts
@@ -41,55 +41,34 @@ export class TermLoader {
     public static loadFromDB(callback : (err?, entities? : Array<Term>) => void) {
         // we are in:   UnstructuredData/out/utils/term-loader.js
         // magic is in: UnstructuredData/api/database.js
-        let database = require("../../api/database.js");
-
-        // optional, if not set: will be taken from API -> database.js -> createContext() -> configDB
-        let databaseURI = undefined;
+        let context = require("../../api/database.js").getContext();
 
         let entities : Array<Term> = [];
 
-        database.connect(databaseURI, function (context) {
-            let artists = context.models.artists;
-            //Use { raw: true } to get raw objects instead of sequelize instances
-            artists.findAll({ raw: true }).then(function(list) {
-                // List is an array of artists objects
-                /*{
-                 name: 'Frank Zappa',
-                 id: '31b9a8b2-dbfe-4107-ba09-4d8bf5dca123',
-                 artist_type: 'composer',  <--- could be null
-                 dateOfBirth: 1940-12-20T23:00:00.000Z,
-                 placeOfBirth: 'Baltimore, Maryland, U.S.',
-                 dateOfDeath: 1993-12-03T23:00:00.000Z,
-                 placeOfDeath: 'Los Angeles, California, U.S.',
-                 nationality: 'American',
-                 tags: [],   <--- could be null
-                 pseudonym: [],  <--- could be null
-                 source_link: 'http://dbpedia.org/resource/Frank_Zappa',
-                 entityId: 'd4158624-7c68-4567-a3e8-b2ade72281d1'
-                 }
-                 */
+        let artists = context.models.artists;
+        //Use { raw: true } to get raw objects instead of sequelize instances
+        artists.findAll({ raw: true }).then(function(list) {
+            // List is an array of artists objects
 
-                // convert all names to Entities
-                for (let inst of list) {
-                    let name : string = inst.name;
-                    let id : string = inst.entityId;
+            // convert all names to Entities
+            for (let inst of list) {
+                let name : string = inst.name;
+                let id : string = inst.entityId;
 
-                    // right now very simple:
-                    // for each part of the name create a new Entity
-                    // add pseudonyms later
-                    let parts = name.split(" ");
-                    for (let part of parts) {
-                        entities.push(new Term(part, id));
-                    }
+                // right now very simple:
+                // for each part of the name create a new Entity
+                // add pseudonyms later
+                let parts = name.split(" ");
+                for (let part of parts) {
+                    entities.push(new Term(part, id));
                 }
+            }
 
-                callback(undefined, entities);
+            callback(undefined, entities);
 
 
-            }).catch(function(error) {
-                if (callback) callback(error);
-            });
-
+        }).catch(function(error) {
+            if (callback) callback(error);
         });
 
     }


### PR DESCRIPTION
storer and term-loader now only need to call require(<databasepath>).getContext() to get context object synchronously.

This is basically just a quick change, connection string creation is borrowed from #135.
This addresses the same issue and should simplify the code.

This also fixes #134 

_Sorry for getting api changes in there._