### PR TITLE
Check if filter output is valid + disabled BloomFilter

### DIFF
--- a/src/webpage-digester.ts
+++ b/src/webpage-digester.ts
@@ -101,9 +101,12 @@ export class WebPageDigester {
         let occs : Array<Occurrence> = [];
         for (let match of matchesIndex) {
             let termStr = match.term;
-            let termID = this.termToIDMap.get(termStr);
+            let entityID = this.termToIDMap.get(termStr);
 
-            occs.push(new Occurrence(new Term(termStr, termID), match.positions));
+            if (!entityID) {
+                console.warn("NO entityID for term " + termStr + "! What is wrong with filters?");
+            }
+            occs.push(new Occurrence(new Term(termStr, entityID), match.positions));
 
         }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -74,7 +74,7 @@ export class Worker {
                          terms : Array<Term>, languageCodes? : Array<string>, caching? : boolean) {
 
         this.webPageDigester = new WebPageDigester(terms)
-            .setPreFilter(BloomFilter)
+            //.setPreFilter(BloomFilter)
             .setFilter(PrefixTree);
 
         this.caching = caching || false;


### PR DESCRIPTION
Every term that we are looking for has an entityID. If filters return something that doesn't have an entityID, it must be very wrong.

Right now, for **8510** rows in contains table, **8509** are **invalid**. The check added in this PR will paint your console red.
