### PR TITLE
Removed BloomFilter as pre-filter for now until it is fixed.

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -74,7 +74,6 @@ export class Worker {
                          terms : Array<Term>, languageCodes? : Array<string>, caching? : boolean) {
 
         this.webPageDigester = new WebPageDigester(terms)
-            .setPreFilter(BloomFilter)
             .setFilter(PrefixTree);
 
         this.caching = caching || false;


### PR DESCRIPTION
This removes the `BloomFilter` as the pre-filter and should **temporarily** fix the issues we're having. 
This is **not** a fix for the root of the problem, but ensures that the app can be used for now without issues.