### PR TITLE
Added blacklist with terms that we should not match

### DIFF
--- a/term-blacklist.txt
+++ b/term-blacklist.txt
@@ -1,0 +1,939 @@
+1848
+7:40
+A Birthday
+A Life
+A Question
+A Tre
+A Vision
+Abel
+Absent
+Agnes
+Aire
+Aladdin
+Alignment
+Alma
+Alta
+Amo
+Amor
+Anita
+Antar
+Anticipation
+Anton
+Arcadia
+Armenia
+Asleep
+Aspire
+Astor
+Astri
+Attraction
+Azerbaijan
+Babylon
+Beati
+Because
+Birds
+Bitte
+Blanche
+Blessing
+Blueberry
+Boston
+Burns
+Carolina
+Chant
+Charge
+Christmas
+Communion
+Conclusion
+Country Club
+Cristina
+Currents
+Demons
+Deployment
+Deutschland
+The small
+Doubt
+Dream
+Dreams
+Eden
+Egypt
+Elves
+Emotions
+Eros
+Study
+Everything
+Exodus
+Expand
+Fascination
+Fede
+Felix
+Fernande
+figure
+Figurines
+Finale
+Fix
+For You
+Frid
+Ghosts
+Gold
+Gone
+Good News
+Ground
+Havana
+Haze
+Heartbeat
+Helen
+Hexagon
+Highland
+Home
+Hope
+I Discovered
+I Know
+Images
+Impression
+Insomnia
+Invention
+Italia
+Jonas
+Julie
+Just In Time
+Lanterns
+Last
+Late
+Legends
+Lent
+Letters
+Liberty
+Lili
+Lillian
+Locations
+Long Ago
+Look!
+Looking Back
+Magic
+Magnolia
+March 2012
+Marche
+Margarita
+Marie
+Marina
+Martian
+Mediterranean
+Messe
+Mickey
+Mimi
+Mirror
+Mirrors
+Monopoly
+Monster
+More and More
+Nava
+New Life
+Nexus
+Nina
+Noodles
+objects
+On and Off
+Orlando
+Suites
+Over There
+Union
+Pater
+Peoria
+Phoenix
+Picnic
+Picture Book
+Pieces
+Policy
+Possession
+Primetime
+Pulse
+Puppets
+Quiet
+RUA
+Raga
+Rajas
+Remember
+Return
+Rewind
+incident
+Riviera
+Robin
+Roman
+Rosemary
+Roses
+Royale
+Russia
+Sacrifice
+Sanga
+Santo
+Scrapbook
+Secrets
+Sermon
+Shanghai
+Silhouette
+Silicon valley
+Simone
+Simples
+Tale
+Soft
+Solomon
+Sorrow
+Spells
+Spheres
+Spiritual
+Spring
+Statements
+Steady
+Stil
+Prayer
+Sunflowers
+Sunrise
+Supplement
+Sweetheart
+Tome
+tbd
+Temptation
+Tender
+Thanksgiving
+Angel
+The Bride
+The Castle
+The Congo
+The Diver
+The Fire
+The Fly
+The Forest
+The Hours
+The Idea
+The Military
+The Press
+The Rat
+The Raven
+The Return
+The Vintage
+The Washington Post
+Alice
+To the old
+Tobacco
+Tomorrow
+Comfort
+Versi
+Victoria
+Violen
+Visions
+Vol
+Wait!
+Wanderlust
+War
+Waves
+Whisper
+wordless
+Zara
+Zimbabwe
+ZOOM IN
+Dialogue
+Responses
+The Lion
+Cora
+one
+10'
+1492
+1804
+A Machine
+A Memory
+A Thought
+Abraham
+Absence
+Africa
+Again
+America
+Andromeda
+Anna
+Anymore
+April
+Aqua
+Arch
+Armor
+Aspiration
+At last
+Austria
+Autumn
+Be ready
+Benny
+Bills
+Blah
+Blond
+Bumps
+Campo
+Capri
+Cartridges
+Cat
+Celebration
+Celebrations
+Chains
+Chinatown
+Cigarette
+Clari
+Coil
+Comet
+Compliment
+Confession
+Confusion
+Constantin
+Continuum
+Core
+Cycles
+Cynthia
+Data
+David
+Desert
+Desir
+Destiny
+Devotion
+Diane
+Disco
+Dora
+Dual
+Dust
+Each Day
+Easter
+Electra
+Electric
+Electromagnet
+Ella
+Elle
+Emira
+Emma
+Enigma
+Era
+Essay
+Exchanges
+Fancy
+Florence
+Fortune
+Fragment
+Friendship
+Genesis
+Gifts
+Grace
+gravity
+Green
+Guarda
+Haiku
+Happy Birthday
+Heaven
+Her Eyes
+Hercules
+Holiday
+Ideal
+Cinna
+Impressions
+In Christ
+In Summer
+In The Country
+In the South
+In the woods
+Independence
+Infinity
+Ingo
+Inni
+Ino
+Inspiration
+Isabel
+Japan
+Jason
+Journal
+Joy
+Karin
+Kindergarten
+Knitting
+Last Post
+Legend
+Lina
+Little Girls
+Lonely
+Love
+Lovers
+Lucifer
+Lux
+Magenta
+Making Money
+March 1
+Maria
+Marseille
+Meditation
+meet
+Memorial
+Memories
+Memory
+Mass
+Midi
+Milestones
+Mona
+Monitor
+In California
+Moscow
+Mystica
+Napoleon
+Bethany
+Night
+Normandy
+Nostalgia
+Nova
+Now!
+Only
+Opal
+Orient
+Our First
+Pan
+Pandora
+Paris
+Pean
+Pictures
+Pierre
+Poems
+Portal
+Exercises
+Prospero
+RAM
+Rast
+Redemption
+Reflections
+Remember Me
+Reward
+Robin Hood
+Romance
+Sketch
+Sakura
+Samuel
+Satan
+Saturday Night
+Scher
+Secret
+Separation
+Iris
+Shur
+Smoke
+Snacks
+Snapshots
+Snowflakes
+Some Day
+Spin
+Storm
+Strategies
+Studies
+Suite
+Suspense
+Tears
+The Flag
+The Letter
+The Oak
+The Park
+The Prison
+The Review
+The Rock
+The Star
+The Sun
+The Wind
+Thora
+Thoughts
+Titanic
+To and Fro
+Topaz
+Travel
+Traveling
+Trilogy
+Trio
+Tripod
+True Love
+Trust
+Tulips
+Twilight
+Variations
+Venice
+Victory
+Virginia
+Vision
+Wallace
+Wang
+Wedding Cake
+Welcome
+Will Tell
+Worship
+You and I
+Your Thoughts
+1776
+A Request
+A Week
+After School
+Angelo
+Annie
+Another Day
+Apart
+As a Gift
+Atlantic
+Enlightenment
+Aurora
+Ballad
+Belle
+Betty
+Bittersweet
+Bleed
+Brunette
+Butterflies
+Canon
+Caravan
+Cause
+Champagne
+CHASING
+Cinderella
+Circles
+Cityscape
+Columbia
+Columbus
+Compensation
+Complaint
+Confidence
+Corpus Christi
+Courage
+Dawn
+Desire
+Dolly
+Dreaming
+Duo
+Dusk
+Edges
+Edward
+Eli
+Elijah
+Elizabeth
+Emporium
+Encore
+Enduring
+England
+Enter In
+Ephemera
+Esther
+Everywhere
+Exile
+Fabric
+Far Away
+Farewell
+Fate
+Final
+Flowering
+Forward
+Glare
+Happiness
+Horizon
+Illusion
+Ima
+In Japan
+In Spring
+In the Spring
+Indigo
+Intermedi
+Isis
+Inventions
+Inventory
+Island
+Islands
+Isolation
+Jefferson
+Joshua
+Julia
+Jerusalem
+Kitty
+Laura
+Opera
+Leaving
+Lesbia
+Lisa
+Lola
+Loss
+Luce
+Maggie
+Mai
+Malvina
+Mania
+Marines
+Masks
+Medium
+Messengers
+Miniature
+Miranda
+Moments
+Moonlight
+Moses
+Musings
+Eva
+Names
+Nanny
+Naples
+Niagara
+No More
+Nonet
+Nora
+Novella
+Oakland
+On Sunday
+On the Water
+Oriental
+Orion
+Pace
+Passage
+Passi
+Peace
+Pearl
+Pfi
+Circulation
+Piece
+Playground
+Portraits
+Pouch
+Poverty
+Powerful
+Light
+Puck
+Rave
+Reflection
+Regret
+Representations
+Rest
+Retrospect
+Rhythms
+Rita
+Roland
+Rosa
+Rose
+Rout
+Ruth
+Sadness
+Saga
+Sally
+Saul
+Seasons
+Sensation
+Sets
+Shadows
+Short Story
+Siberia
+Silva
+Snaps
+Sne
+Sofia
+Sometimes
+Sphinx
+Sport
+Study I
+Summer
+Summertime
+sunday
+Sunset
+Swan
+Testimony
+The Answer
+The Argument
+The Choice
+The Cloud
+The Cry
+The Empire
+The Enterprise
+The Flow
+The Fox
+The Garden
+The Land
+March
+The Months
+The Poet
+The River
+The Sea
+The Sigh
+The Style
+The Tournament
+Thomas
+Three Months
+Thumbnails
+Time Off
+To Sleep
+Toast
+Together
+Torna
+Toto
+Tragedy
+trans
+Tribute
+Tune
+Until
+Valentines
+Aria
+Voyage
+Waiting for you
+Wall street
+Wanda
+Warmth
+Why?
+Winter
+Wonder
+Wow
+Yank
+Yesterday
+Yukon
+Zero
+Zion
+Grave
+1977
+001
+1814
+1922
+300
+A dream
+Ada
+Adelaide
+Advent
+Air
+Alba
+Allah
+Alone
+Alyssa
+Amen
+Answer?
+Applicatio
+Arie
+Ariel
+Arrangements
+Awakening
+Balance
+Beauty
+Bella
+Bells
+Selection
+Bicycle
+Black & White
+Brais
+Breakout
+Businessman
+By the Sea
+Byron
+Carlisle
+Cassandra
+Chameleon
+Cherry
+Christmas Eve
+Cid
+Clara
+Clouds
+Condor
+Conservatory
+Conversation
+Correspondence
+Credits
+Cycle
+Cypress
+Death
+December
+Decorations
+Dedication
+Diana
+The Night
+Echo
+Ecstasy
+Elevation
+Episodes
+Essays
+Evening
+Evolution
+Expectation
+Extrem
+Fable
+Faith
+Fame
+Fedora
+Few Days
+Flat
+Flirt
+Flora
+Florida
+Flourish
+For Life
+Forgotten
+Fourth of July
+Fragrance
+Frenzy
+Garcia
+Garland
+Gato
+Giga
+Gladiator
+Greenwood
+Growing Up
+Hamburg
+handles
+Heart
+Heat
+Hebe
+Histories
+Holes
+Homeland
+Hora
+Illustration
+Illustrations
+In C
+In India
+In a Nutshell
+In memoriam
+In the Dark
+Indiana
+Innocence
+Interviews
+Isla
+Investigation
+Italiana
+Jewel
+Job
+Joseph
+Journey
+Juliet
+June
+Jupiter
+calenda
+Keepsake
+Elite
+Lace
+Landscape
+Landscapes
+Lara
+Leone
+Life
+Longing
+Lost and Found
+Lust
+LYNDA
+Madeleine
+Madrid
+Marine
+Mars
+Meteor
+Midnight
+Milton
+Miniatures
+Mirage
+Misa
+More or Less
+Morning
+Music
+My Own
+Narciss
+Nine
+Nirvana
+No!
+Norma
+Norwich
+Notre Dame
+Novelty
+Noel
+October
+Ode
+On Time
+Particles
+Passion
+Passions
+Pastel
+Patti
+Pegasus
+Peri
+Fantasy
+Pharao
+Classical
+Poem
+Polska
+Portrait
+Pride
+Provence
+Question
+Rain
+Reeds
+Regina
+Reindeer
+Relaxation
+Remains
+Resolution
+Roma
+Romantic
+rotation
+Rugby
+S-C
+Samson
+Sanctuary
+Second Hand
+shaw
+Silence
+Silver
+Silvia
+sitting
+Slow
+Snow White
+Sol
+Somebody
+Stella
+Step by Step
+Stone
+Story
+Studie
+Studio
+Glee
+Tallahassee
+Tamara
+Tear
+Testament
+The Beast
+The bottle
+The Clouds
+The Cost
+The Critic
+The Dream
+The Family
+The Horse
+The Lake
+The Message
+The Mill
+The Mother
+The Other Side
+The Past
+The Quest
+The Question
+The Road
+The Search
+The Secret
+The Source
+The Storm
+The Story
+The Wife
+The Worker
+Thea
+Tides
+Trains
+Triumph
+Turn
+Two
+Types
+Vanda
+Vanishing
+Warm
+Waterways
+Racing
+Who?
+Wind
+Wish
+Wonderland
+Woodland
+World War II
+You
+You!
+Your way
+Alfred
+Parade
+España
+Deo
+The Nose
+Messiah
+Psyche


### PR DESCRIPTION
### Term Blacklist
This is version 0.1 and should definetely be improved in the future..
I've been over the terms by hand to pick out the ones that should not be in the blacklist. 
They have mostly been picked using the following query:
```
SELECT * 
FROM entities LEFT JOIN artists ON artists."entityId" = entities.id 
   LEFT JOIN instruments ON instruments."entityId" = entities.id 
   LEFT JOIN works ON works."entityId" = entities.id 
   LEFT JOIN releases ON releases."entityId" = entities.id
WHERE entities.id IN (
   SELECT "entityId"
   FROM contains GROUP BY "entityId" 
   ORDER BY COUNT(*) DESC 
   LIMIT 1000)
```

_PS: Yes, I know this query can be improved._
