### PR TITLE
Added correct content length and removed unnecessary block digest

### DIFF
--- a/src/classes/webpage.ts
+++ b/src/classes/webpage.ts
@@ -71,11 +71,18 @@ export class WebPage {
         // protocol
         let str : string = this.protocol + '\n';
         // properties
-        for (let property in this.headers) {
-            str += property + ': ' + this.headers[property] + '\n';
+        this.headers["Content-Length"] = Buffer.byteLength(this.content, 'utf8').toString();
+        const properties = [
+            "WARC-Type", "WARC-Target-URI", "WARC-Date", "WARC-Record-ID",
+            "WARC-Refers-To", "Content-Type", "Content-Length"
+        ];
+        for (let property of properties) {
+            if (this.headers.hasOwnProperty(property)) {
+                str += property + ': ' + this.headers[property] + '\n';
+            }
         }
         // content
-        str += '\n' + this.content + '\n\n';
+        str += '\n' + this.content + '\n\n\n';
         return str;
     }
 

--- a/src/test/classes/webpage-test.ts
+++ b/src/test/classes/webpage-test.ts
@@ -20,8 +20,9 @@ describe("WebPage", () => {
         let expected = "WARC/1.0" +
             "\nWARC-Type: conversion" +
             "\nWARC-Target-URI: https://host.com/a/path.html" +
+            "\nContent-Length: " + 70 +
             "\n\nSome sample text, yay!\nA word.\nNow with more a lot more lines!\nAnother" +
-            "\n\n";
+            "\n\n\n";
         assert.strictEqual(new WebPage(generateDummyWARC("https://host.com/a/path.html")).toWARCString(), expected);
     });
     it("should return empty string as TLD of IPv4 address", () => {


### PR DESCRIPTION
- Added missing new line after content

- Content length is no accurate

- Removed unnescessary `WARC-Block-Digest` header