### PR TITLE
Increased the speed of populating the queue

### DIFF
--- a/src/master-process.ts
+++ b/src/master-process.ts
@@ -102,13 +102,11 @@ export class MasterProcess {
         let onPathsLoaded = () => {
             let pushed = 0;
 
-            // iterate over all paths and push then to the queue, 20 at a time
-            async.mapLimit(paths, 20, (path, cb) => {
+            // iterate over all paths and push then to the queue, 100 at a time
+            async.mapLimit(paths, 100, (path, cb) => {
                 pushPath(path, (err) => {
-                    if (err) {
-                        winston.error("Failed to push to queue: " + path, err);
-                    } else {
-                        winston.info("Pushed " + (++pushed) + "/" + paths.length + " successfully to queue: " + path);
+                    if (!err) {
+                        winston.info("Pushed " + (++pushed) + "/" + paths.length + " paths successfully to queue!");
                     }
                     cb();
                 }, 5);
@@ -117,9 +115,14 @@ export class MasterProcess {
 
         let pushPath = (path: string, callback?: (err?: Error) => void, retries?: number) => {
             MasterProcess.queueService.createMessage(MasterProcess.queueName, path, (err) => {
-                if (err && retries > 0) {
-                    setTimeout(() => pushPath(path, callback, retries - 1), 60000);
+                if (!err) {
+                    winston.info("Successfully push to queue: " + path);
+                    callback();
+                } else if (retries > 0) {
+                    winston.error("Failed to push to queue! retrying in 20 seconds: " + path, err);
+                    setTimeout(() => pushPath(path, callback, retries - 1), 20000);
                 } else {
+                    winston.error("Finally failed to push to queue: " + path, err);
                     callback(err);
                 }
             });

--- a/src/master-process.ts
+++ b/src/master-process.ts
@@ -116,7 +116,7 @@ export class MasterProcess {
         let pushPath = (path: string, callback?: (err?: Error) => void, retries?: number) => {
             MasterProcess.queueService.createMessage(MasterProcess.queueName, path, (err) => {
                 if (!err) {
-                    winston.info("Successfully push to queue: " + path);
+                    winston.info("Successfully pushed to queue: " + path);
                     callback();
                 } else if (retries > 0) {
                     winston.error("Failed to push to queue! retrying in 20 seconds: " + path, err);


### PR DESCRIPTION
- Increased the number of concurrent connections to 100

- Improved logging

Sometimes we'll get a timeout error despite Azure already having pushed the path to the queue. This will result in a duplicate path in the queue. This is very rare though <<1%.