### PR TITLE
Added option to store metadata as JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,11 @@ Alternatively to supplying all the arguments via the CLI they can be set via the
   "queueAccount": "parsertaskqueue",
   "queueName": "taskqueue",
   "queueKey": "AZURE_KEY_HERE",
-  "processes": 4,
   "heuristicThreshold": 3,
   "heuristicLimit": 7,
   "avgLineLength": 100,
+  "processes": 4,
+  "useJson": false,
   "languageCodes": [
     "de",
     "en",

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Once that's finished run `npm run compile` to compile everything to Javascript.
 
 ## Usage
 ```
-  Usage: app [options]
+$ Usage: app [options]
 
-  Options:
+> Options:
 
     -h, --help                                output usage information
     -P, --Process                             process queue items
@@ -26,12 +26,14 @@ Once that's finished run `npm run compile` to compile everything to Javascript.
     -a, --db-access [user]:[password]         database access, e.g. "USER:PASSWORD"
     -n, --db-name [name]                      database name, e.g. "ProductionDB"
     -b, --blob-access [account]:[accessKey]   blob storage credentials, e.g. "wetstorage:AZURE_KEY_HERE"
-    -c, --blob-container [containerName]      blob storage container name, e.g. "websites"
+    -c, --blob-container [containerName]      blob storage container name for website content, e.g. "websites"
+    -j, --json-container [containerName]      blob storage container name for metadata, e.g. "metadata"
     -q, --queue-access [account]:[accessKey]  task queue credentials, e.g. "queueservice:AZURE_KEY_HERE"
     -s, --queue-name [queueName]              task queue name, e.g. "taskqueue"
-    --processes [number]                      number of worker threads, e.g. "4"
     -t, --heuristic [threshold]:[limit]       filter strictness, the higher the stricter, e.g. "3", "3:7" (inclusive:exclusive)
     -l, --avg-line-length [length]            remove short lines from content before filtering, e.g. "100"
+    --processes [number]                      number of worker threads, e.g. "4"
+    --use-json                                save metadata to json container instead of DB
     --languages [languageCodes]               languages to filter for in ISO 639-1, e.g. "['de', 'en', 'fr']"
     --enable-pre-filter                       enable bloom filter as pre filter
     --crawl-version [version]                 common crawl version, e.g. "CC-MAIN-2017-13"
@@ -61,17 +63,19 @@ Once that's finished run `npm run compile` to compile everything to Javascript.
     Defaults to the number of logical CPU cores.
   - `-t`, `--heuristic-threshold` sets the filter strictness, the higher the stricter.    
     Threshold defaults to 3, limit to infinity.   
+  - `--use-json` can be set to save the resulting metadata to the specified JSON container instead of the DB.   
   - `--wet-caching` can be used to save the downloaded and processed WET files to disk. (EXPERIMENTAL)
 - Option `-M`, `--Monitor` will constantly monitor the queue size.  
 - Option `--Delete-queue` will permanently delete the queue.   
 This mode can't be combined with any other operating mode. If multiple modes are selected only `--Delete-queue` will be run.
 
 The following arguments will only be used when using mode `-P`, `--Process`:
-- `-d`, `--db-location`
-- `-a`, `--db-access`
-- `-n`, `--db-name`
-- `-b`, `--blob-access`
-- `-c`, `--blob-container`
+- `-d`, `--db-location`, defaults to "localhost:5432"
+- `-a`, `--db-access`, has no default value
+- `-n`, `--db-name`, has no default value
+- `-b`, `--blob-access`, has no default value
+- `-c`, `--blob-container`, defaults to "websites"
+- `-j`, `--json-conatiner`, defaults to "metadata"
 
 
 

--- a/src/storer.ts
+++ b/src/storer.ts
@@ -7,69 +7,77 @@ import * as uuid from "uuid/v4";
 
 export class Storer {
 
-    private container;
-    private blobService;
-    private dbConnectionString : string;
-    // this guy has to be initialized with connectToDB()!
-    private context;
-    //This could be left out but it makes it easier for the other groups to access the blobs if we store them with fqdn
+    private storageService;
+    private blobContainer : string;
     private blobPrefix : string;
+    private jsonContainer : string;
 
-    private blob : {name : string, entries : Array<WebPage>};
-    private websites : Array<{id : string, url : string, blobUrl : string, occurrences : Array<Occurrence>}> = [];
+    private saveMetadataJSON : boolean;
 
-    constructor(blobParams : {[param : string] : string }, dbParams : {[param : string] : string}){
+    private context;
+    private connectToDB : (callback : (err? : Error) => void, retries? : number) => void = (callback) => {
+        callback(new TypeError("method not defined"));
+    };
 
-        let blobAccount = blobParams["blobAccount"];
-        let blobContainer = blobParams["blobContainer"];
-        let blobKey = blobParams["blobKey"];
+    private blob : {name : string, content : string} = {name: uuid(), content: ""};
+    private websites : Array<{url : string, blobUrl : string, occurrences : Array<Occurrence>}> = [];
 
-        this.blobService = azure.createBlobService(
+    /**
+     * This object is responsible for saving web page content and metadata. Content will be stored in the
+     * supplied Azure blob storage container. Metadata will be saved in a separate storage container or in
+     * a Postgres DB if supplied
+     * @param blobParams                                    details of Azure storage account and containers
+     * @param dbParams                                      (optional) credentials for Postgres DB
+     */
+    constructor(blobParams : {blobAccount : string, blobKey : string, blobContainer : string, jsonContainer : string },
+                dbParams? : {dbUser : string, dbPW : string, dbHost : string, dbPort : string, dbName : string}){
+
+        let blobAccount = blobParams.blobAccount;
+        let blobKey = blobParams.blobKey;
+        this.blobContainer = blobParams.blobContainer;
+        this.jsonContainer = blobParams.jsonContainer;
+
+        this.storageService = azure.createBlobService(
             blobAccount,
             blobKey
         );
-        this.blobPrefix = 'https://' + blobAccount +
-            '.blob.core.windows.net/' + blobContainer + '/';
-        this.container = blobContainer;
-        this.blobService.createContainerIfNotExists(blobContainer, err => {
-            if (err) {
-                winston.error("Couldn't create blob container!", err);
-            }
-        });
+        this.blobPrefix = 'https://' + blobAccount + '.blob.core.windows.net/' + this.blobContainer + '/';
 
-        this.dbConnectionString = "postgresql://"
-            + dbParams["dbUser"] + ":"
-            + dbParams["dbPW"] + "@"
-            + dbParams["dbHost"] + ":"
-            + dbParams["dbPort"] + "/"
-            + dbParams["dbName"];
-    }
+        if (dbParams) {
+            this.connectToDB = (callback : (err? : Error) => void, retries? : number) => {
+                let dbConnectionString = "postgresql://"
+                    + dbParams.dbUser + ":"
+                    + dbParams.dbPW + "@"
+                    + dbParams.dbHost + ":"
+                    + dbParams.dbPort + "/"
+                    + dbParams.dbName;
 
-
-    private connectToDB(callback : (err? : Error) => void, retries? : number) : void {
-
-        //Connect to database using api's index
-        require('../api/database').connect(this.dbConnectionString, context => {
-            //Store context
-            this.context = context;
-            /*
-             Make sure that syncing to database is synchronous.
-             Not that there is no {force: true} option here: We don't want to overwrite
-             existing tables.
-             */
-            context.sequelize.sync().then(() => {
-                winston.info("Connection to DB established!");
-                callback();
-            }, (err) => {
-                if (retries > 0) {
-                    winston.error("Failed to connect to DB. Retrying in 60 seconds!", err);
-                    setTimeout(() => this.connectToDB(callback, retries - 1), 6000);
-                } else {
-                    winston.error("Finally failed to connect to DB. Calling Callback!", err);
-                    callback(err);
-                }
-            });
-        });
+                //Connect to database using api's index
+                require('../api/database').connect(dbConnectionString, context => {
+                    //Store context
+                    this.context = context;
+                    /*
+                     Make sure that syncing to database is synchronous.
+                     Not that there is no {force: true} option here: We don't want to overwrite
+                     existing tables.
+                     */
+                    context.sequelize.sync().then(() => {
+                        winston.info("Connection to DB established!");
+                        callback();
+                    }, (err) => {
+                        if (retries > 0) {
+                            winston.error("Failed to connect to DB. Retrying in 60 seconds!", err);
+                            setTimeout(() => this.connectToDB(callback, retries - 1), 6000);
+                        } else {
+                            winston.error("Finally failed to connect to DB. Calling Callback!", err);
+                            callback(err);
+                        }
+                    });
+                });
+            };
+        } else {
+            this.saveMetadataJSON = true;
+        }
     }
 
 
@@ -79,8 +87,8 @@ export class Storer {
      * It will collect data until you call .flush()
      * @param webPage
      */
-    public storeWebsite(webPage : WebPage) : void {
-        this.storeWebsiteBlob(webPage).storeWebsiteMetadata(webPage);
+    public storeWebsite(webPage : WebPage) : Storer {
+        return this.storeWebsiteBlob(webPage).storeWebsiteMetadata(webPage);
     }
 
 
@@ -88,14 +96,12 @@ export class Storer {
      * This doesn't actually save to the DB immediately. It will collect data until you call .flushDatabase()
      * @param webPage
      */
-    private storeWebsiteMetadata(webPage : WebPage) {
+    private storeWebsiteMetadata(webPage : WebPage) : Storer {
         this.websites.push({
-            id: uuid(),
             url: webPage.getURI(),
             blobUrl: this.blob ? this.blobPrefix + this.blob.name : null,
             occurrences: webPage.occurrences
         });
-
         return this;
     }
 
@@ -108,14 +114,8 @@ export class Storer {
      *
      * @param webPage       WebPage object to be stored
      */
-    private storeWebsiteBlob(webPage : WebPage) {
-        if (!this.blob) {
-            this.blob = {
-                name: uuid(),
-                entries: []
-            };
-        }
-        this.blob.entries.push(webPage);
+    private storeWebsiteBlob(webPage : WebPage) : Storer {
+        this.blob.content += webPage.toWARCString();
         return this;
     }
 
@@ -125,33 +125,37 @@ export class Storer {
             if(err) {
                 return callback(err);
             }
-            this.flushDatabase(err => {
-                if(err) {
-                    return callback(err);
-                }
-                callback();
-            }, retries)
+            if (this.saveMetadataJSON) {
+                this.flushMetadataJSON(err => {
+                    if(err) {
+                        return callback(err);
+                    }
+                    callback();
+                }, retries)
+            } else {
+                this.flushMetadataDB(err => {
+                    if(err) {
+                        return callback(err);
+                    }
+                    callback();
+                }, retries)
+            }
         }, retries);
     }
 
 
     private flushBlob(callback? : (err? : Error) => void, retries? : number) : void {
 
-        let blobContent = "";
-        for (let entry of this.blob.entries) {
-            blobContent += entry.toWARCString();
-        }
-
         let blobName = this.blob.name;
-        Unpacker.compressStringToBuffer(blobContent, (err, compressedBlobContent) => {
+        Unpacker.compressStringToBuffer(this.blob.content, (err, compressedBlobContent) => {
             if (err) {
                 if (callback) callback(err);
                 return;
             }
-            this.blobService.createBlockBlobFromText(this.container, blobName, compressedBlobContent, (err) => {
+            this.storageService.createBlockBlobFromText(this.blobContainer, blobName, compressedBlobContent, (err) => {
                 if (!err) {
                     winston.info("Successfully offloaded blob!");
-                    this.blob = undefined;
+                    this.blob = {name: uuid(), content: ""};
                     if (callback) callback();
                 } else if (retries > 0) {
                     winston.error("Failed to offload blob! Retrying in 60 seconds!", err);
@@ -165,13 +169,30 @@ export class Storer {
     }
 
 
-    private flushDatabase(callback ? : (err? : Error) => void, retries? : number) : void {
+    private flushMetadataJSON(callback ? : (err? : Error) => void, retries? : number) : void {
+        let blobName = uuid() + ".json";
+        let blobContent = JSON.stringify(this.websites);
+        this.storageService.createBlockBlobFromText(this.jsonContainer, blobName, blobContent, (err) => {
+            if (!err) {
+                winston.info("Successfully offloaded metadata blob!");
+                if (callback) callback();
+            } else if (retries > 0) {
+                winston.error("Failed to offload metadata blob! Retrying in 60 seconds!", err);
+                setTimeout(() => this.flushMetadataJSON(callback, retries - 1), 60000);
+            } else {
+                winston.error("Finally failed to offload metadata blob! Calling callback!", err);
+                if (callback) callback(err);
+            }
+        });
+    }
+
+    private flushMetadataDB(callback ? : (err? : Error) => void, retries? : number) : void {
 
         // lazily load sequelize context
         if (!this.context) {
             return this.connectToDB((err) => {
                 if (!err) {
-                    this.flushDatabase(callback, retries);
+                    this.flushMetadataDB(callback, retries);
                 } else if (callback) {
                     callback(err);
                 }
@@ -212,7 +233,7 @@ export class Storer {
         }).catch(err => {
             if (retries > 0) {
                 winston.error("Failed to offload data to DB! Retrying in 60 seconds!", err);
-                setTimeout(() => this.connectToDB(() => this.flushDatabase(callback, retries - 1)), 60000);
+                setTimeout(() => this.connectToDB(() => this.flushMetadataDB(callback, retries - 1)), 60000);
             } else {
                 winston.error("Finally failed to offload data to DB! Calling callback!", err);
                 if (callback) callback(err);

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -29,12 +29,14 @@ export class CLI {
             .option('-a, --db-access [user]:[password]', 'database access, e.g. "USER:PASSWORD"')
             .option('-n, --db-name [name]', 'database name, e.g. "ProductionDB"')
             .option('-b, --blob-access [account]:[accessKey]', 'blob storage credentials, e.g. "wetstorage:AZURE_KEY_HERE"')
-            .option('-c, --blob-container [containerName]', 'blob storage container name, e.g. "websites"')
+            .option('-c, --blob-container [containerName]', 'blob storage container name for website content, e.g. "websites"')
+            .option('-j, --json-container [containerName]', 'blob storage container name for metadata, e.g. "metadata"')
             .option('-q, --queue-access [account]:[accessKey]', 'task queue credentials, e.g. "queueservice:AZURE_KEY_HERE"')
             .option('-s, --queue-name [queueName]', 'task queue name, e.g. "taskqueue"')
-            .option('--processes [number]', 'number of worker threads, e.g. "4"')
             .option('-t, --heuristic [threshold]:[limit]', 'filter strictness, the higher the stricter, e.g. "3", "3:7" (inclusive:exclusive)')
             .option('-l, --avg-line-length [length]', 'remove short lines from content before filtering, e.g. "100"')
+            .option('--processes [number]', 'number of worker threads, e.g. "4"')
+            .option('--use-json', 'save metadata to json container instead of DB')
             .option('--languages [languageCodes]', 'languages to filter for in ISO 639-1, e.g. "[\'de\', \'en\', \'fr\']"')
             .option('--enable-pre-filter', 'enable bloom filter as pre filter')
             .option('--crawl-version [version]', 'common crawl version, e.g. "CC-MAIN-2017-13"')
@@ -98,6 +100,10 @@ export class CLI {
             this.parameters["blobContainer"] = this.commander.blobContainer;
         }
 
+        if (this.commander.jsonContainer) {
+            this.parameters["jsonContainer"] = this.commander.jsonContainer;
+        }
+
         if (this.commander.queueAccess) {
             let split = this.commander.queueAccess.split(":", 2);
             if (split.length < 2) {
@@ -112,11 +118,6 @@ export class CLI {
             this.parameters["queueName"] = this.commander.queueName;
         }
 
-        if (this.commander.processes) {
-            let processes = parseInt(this.commander.processes);
-            if (processes) this.parameters["processes"] = processes;
-        }
-
         if (this.commander.heuristic) {
             let split = this.commander.heuristic.split(":", 2);
             let threshold = parseFloat(split[0]);
@@ -128,6 +129,15 @@ export class CLI {
         if (this.commander.avgLineLength) {
             let length = parseFloat(this.commander.avgLineLength);
             if (length) this.parameters["avgLineLength"] = length;
+        }
+
+        if (this.commander.processes) {
+            let processes = parseInt(this.commander.processes);
+            if (processes) this.parameters["processes"] = processes;
+        }
+
+        if (this.commander.useJson) {
+            this.parameters["useJson"] = this.commander.useJson;
         }
 
         if (this.commander.languages) {

--- a/src/utils/param-loader.ts
+++ b/src/utils/param-loader.ts
@@ -20,9 +20,8 @@ export class ParamLoader {
     public DEFAULT ={
         dbHost: "localhost",
         dbPort: "5432",
-        dbDatabase: "mcm",
-        blobAccount: "wetstorage",
         blobContainer: "websites",
+        jsonContainer: "metadata",
         processes: os.cpus().length,
         crawlVersion: "CC-MAIN-2017-13",
         heuristicThreshold: 3,
@@ -53,7 +52,7 @@ export class ParamLoader {
         };
 
         group(["dbHost", "dbPort", "dbName", "dbUser", "dbPW"], "dbParams");
-        group(["blobAccount", "blobContainer", "blobKey"], "blobParams");
+        group(["blobAccount", "blobKey", "blobContainer", "jsonContainer"], "blobParams");
         group(["queueAccount", "queueName", "queueKey"], "queueParams");
     }
 

--- a/src/worker-process.ts
+++ b/src/worker-process.ts
@@ -38,13 +38,15 @@ export class WorkerProcess {
 
                 WorkerProcess.worker = new Worker(
                     msg.terms,
+                    new Storer(
+                        params.all.blobParams,
+                        (params.all.useJson) ? undefined : params.all.dbParams
+                    ),
                     {
                         heuristicThreshold: params.all.heuristicThreshold,
                         heuristicLimit: params.all.heuristicLimit,
                         avgLineLength: params.all.avgLineLength
                     },
-                    params.all.blobParams,
-                    (params.all.useJson) ? undefined : params.all.dbParams,
                     {
                         languageCodes: params.all.languageCodes,
                         caching: params.all.caching,
@@ -145,21 +147,18 @@ class Worker {
 
 
     /**
-     * @param blobParams                                    Azure blob storage access data
-     * @param dbParams                                      Database access data
      * @param terms                                         Array of entities to filter for
+     * @param storer                                        Storer for saving results
      * @param filterParams                                  Filter settings
-     * @param options                                       optional parameters
+     * @param options                                       (optional) optional parameters
      */
-    public constructor (terms : Array<Term>,
-                        filterParams : { heuristicThreshold : number, heuristicLimit : number, avgLineLength : number},
-                        blobParams : { blobAccount : string, blobKey : string, blobContainer : string, jsonContainer : string},
-                        dbParams? : {dbUser : string, dbPW : string, dbHost : string, dbPort : string, dbName : string},
-                        options? : {caching? : boolean, languageCodes: Array<string>, enablePreFilter : boolean}) {
+    public constructor (terms : Array<Term>, storer : Storer,
+                        filterParams : { heuristicThreshold : number, heuristicLimit : number, avgLineLength : number },
+                        options? : { caching? : boolean, languageCodes: Array<string>, enablePreFilter : boolean }) {
 
         this.webPageDigester = new WebPageDigester(terms).setFilter(PrefixTree);
 
-        this.storer = new Storer(blobParams, dbParams);
+        this.storer = storer;
         this.heuristicThreshold = filterParams.heuristicThreshold;
         this.heuristicLimit = filterParams.heuristicLimit;
         this.avgLineLength = filterParams.avgLineLength;

--- a/src/worker-process.ts
+++ b/src/worker-process.ts
@@ -37,15 +37,19 @@ export class WorkerProcess {
                 winston.info("Received " + msg.terms.length + " terms!");
 
                 WorkerProcess.worker = new Worker(
-                    params.all.blobParams,
-                    params.all.dbParams,
                     msg.terms,
-                    params.all.heuristicThreshold,
-                    params.all.heuristicLimit,
-                    params.all.avgLineLength,
-                    params.all.languageCodes,
-                    params.all.caching,
-                    params.all.enablePreFilter
+                    {
+                        heuristicThreshold: params.all.heuristicThreshold,
+                        heuristicLimit: params.all.heuristicLimit,
+                        avgLineLength: params.all.avgLineLength
+                    },
+                    params.all.blobParams,
+                    (params.all.useJson) ? undefined : params.all.dbParams,
+                    {
+                        languageCodes: params.all.languageCodes,
+                        caching: params.all.caching,
+                        enablePreFilter: params.all.enablePreFilter,
+                    }
                 );
 
                 WorkerProcess.startProcessing();
@@ -142,32 +146,31 @@ class Worker {
 
     /**
      * @param blobParams                                    Azure blob storage access data
-     * @param dbParams                                      database access data
+     * @param dbParams                                      Database access data
      * @param terms                                         Array of entities to filter for
-     * @param heuristicThreshold                            threshold for heuristic
-     * @param heuristicLimit                                limit for heuristic
-     * @param avgLineLength                                 shrink web page content to avg line length
-     * @param languageCodes                                 (optional) Array of languages to filter for
-     * @param caching                                       (optional) enable WET file caching
-     * @param enablePreFilter                               (optional) enable pre filter
+     * @param filterParams                                  Filter settings
+     * @param options                                       optional parameters
      */
-    public constructor (blobParams : {[param : string] : string }, dbParams : {[param : string] : string },
-                        terms : Array<Term>, heuristicThreshold : number, heuristicLimit : number,
-                        avgLineLength : number, languageCodes? : Array<string>, caching? : boolean,
-                        enablePreFilter? : boolean) {
+    public constructor (terms : Array<Term>,
+                        filterParams : { heuristicThreshold : number, heuristicLimit : number, avgLineLength : number},
+                        blobParams : { blobAccount : string, blobKey : string, blobContainer : string, jsonContainer : string},
+                        dbParams? : {dbUser : string, dbPW : string, dbHost : string, dbPort : string, dbName : string},
+                        options? : {caching? : boolean, languageCodes: Array<string>, enablePreFilter : boolean}) {
 
         this.webPageDigester = new WebPageDigester(terms).setFilter(PrefixTree);
 
-        if (enablePreFilter) {
-            this.webPageDigester.setPreFilter(BloomFilter);
-        }
-
-        this.caching = caching || false;
-        this.languageCodes = languageCodes;
         this.storer = new Storer(blobParams, dbParams);
-        this.heuristicThreshold = heuristicThreshold;
-        this.heuristicLimit = heuristicLimit;
-        this.avgLineLength = avgLineLength;
+        this.heuristicThreshold = filterParams.heuristicThreshold;
+        this.heuristicLimit = filterParams.heuristicLimit;
+        this.avgLineLength = filterParams.avgLineLength;
+
+        if (options) {
+            this.caching = options.caching || false;
+            this.languageCodes = options.languageCodes;
+            if (options.enablePreFilter) {
+                this.webPageDigester.setPreFilter(BloomFilter);
+            }
+        }
     }
 
 


### PR DESCRIPTION
- Slightly reworked `Storer`
  - when no `dbParams` are supplied it will save all metadata as JSON files on a separate Azure blob storage container
  - `flush` method has a new optional parameter which changes the behavior of the method as if no `dbParams` were supplied in the constructor
- Changed control flow slightly in `worker-process.ts`